### PR TITLE
feat(Formatters): added `hyperlink` and `hideLinkEmbed`

### DIFF
--- a/src/messages/formatters.ts
+++ b/src/messages/formatters.ts
@@ -1,3 +1,5 @@
+import type { URL } from 'url';
+
 /**
  * Wraps the content inside a codeblock with no language.
  * @param content The content to wrap.
@@ -77,6 +79,65 @@ export function quote<C extends string>(content: C): `> ${C}` {
  */
 export function blockQuote<C extends string>(content: C): `>>> ${C}` {
 	return `>>> ${content}`;
+}
+
+/**
+ * Formats the URL into `<>`, which stops it from embedding.
+ * @param url The URL to wrap.
+ * @returns The formatted content.
+ */
+export function maskLink<C extends string>(url: C): `<${C}>`;
+
+/**
+ * Formats the URL into `<>`, which stops it from embedding.
+ * @param url The URL to wrap.
+ * @returns The formatted content.
+ */
+export function maskLink(url: URL): `<${string}>`;
+export function maskLink(url: string | URL) {
+	return `<${typeof url === 'object' ? url.href : url}>`;
+}
+
+/**
+ * Formats the content and the URL into a masked URL.
+ * @param content The content to display.
+ * @param url The URL the content links to.
+ * @returns The formatted content.
+ */
+export function hyperlink<C extends string>(content: C, url: URL): `[${C}](${string})`;
+
+/**
+ * Formats the content and the URL into a masked URL.
+ * @param content The content to display.
+ * @param url The URL the content links to.
+ * @returns The formatted content.
+ */
+export function hyperlink<C extends string, U extends string>(content: C, url: U): `[${C}](${U})`;
+
+/**
+ * Formats the content and the URL into a masked URL.
+ * @param content The content to display.
+ * @param url The URL the content links to.
+ * @param title The title shown when hovering on the masked link.
+ * @returns The formatted content.
+ */
+export function hyperlink<C extends string, T extends string>(content: C, url: URL, title: T): `[${C}](${string} ${T})`;
+
+/**
+ * Formats the content and the URL into a masked URL.
+ * @param content The content to display.
+ * @param url The URL the content links to.
+ * @param title The title shown when hovering on the masked link.
+ * @returns The formatted content.
+ */
+export function hyperlink<C extends string, U extends string, T extends string>(
+	content: C,
+	url: U,
+	title: T,
+): `[${C}](${U} ${T})`;
+export function hyperlink(content: string, url: string | URL, title?: string) {
+	if (typeof url === 'object') url = url.href;
+	return title ? `[${content}](${url} ${title})` : `[${content}](${url})`;
 }
 
 /**

--- a/src/messages/formatters.ts
+++ b/src/messages/formatters.ts
@@ -95,6 +95,7 @@ export function maskedLink<C extends string>(url: C): `<${C}>`;
  */
 export function maskedLink(url: URL): `<${string}>`;
 export function maskedLink(url: string | URL) {
+	// eslint-disable-next-line @typescript-eslint/restrict-template-expressions
 	return `<${url}>`;
 }
 
@@ -136,6 +137,7 @@ export function hyperlink<C extends string, U extends string, T extends string>(
 	title: T,
 ): `[${C}](${U} ${T})`;
 export function hyperlink(content: string, url: string | URL, title?: string) {
+	// eslint-disable-next-line @typescript-eslint/restrict-template-expressions
 	return title ? `[${content}](${url} ${title})` : `[${content}](${url})`;
 }
 

--- a/src/messages/formatters.ts
+++ b/src/messages/formatters.ts
@@ -86,15 +86,15 @@ export function blockQuote<C extends string>(content: C): `>>> ${C}` {
  * @param url The URL to wrap.
  * @returns The formatted content.
  */
-export function maskedLink<C extends string>(url: C): `<${C}>`;
+export function hideLinkEmbed<C extends string>(url: C): `<${C}>`;
 
 /**
  * Formats the URL into `<>`, which stops it from embedding.
  * @param url The URL to wrap.
  * @returns The formatted content.
  */
-export function maskedLink(url: URL): `<${string}>`;
-export function maskedLink(url: string | URL) {
+export function hideLinkEmbed(url: URL): `<${string}>`;
+export function hideLinkEmbed(url: string | URL) {
 	// eslint-disable-next-line @typescript-eslint/restrict-template-expressions
 	return `<${url}>`;
 }

--- a/src/messages/formatters.ts
+++ b/src/messages/formatters.ts
@@ -86,15 +86,15 @@ export function blockQuote<C extends string>(content: C): `>>> ${C}` {
  * @param url The URL to wrap.
  * @returns The formatted content.
  */
-export function maskLink<C extends string>(url: C): `<${C}>`;
+export function maskedLink<C extends string>(url: C): `<${C}>`;
 
 /**
  * Formats the URL into `<>`, which stops it from embedding.
  * @param url The URL to wrap.
  * @returns The formatted content.
  */
-export function maskLink(url: URL): `<${string}>`;
-export function maskLink(url: string | URL) {
+export function maskedLink(url: URL): `<${string}>`;
+export function maskedLink(url: string | URL) {
 	return `<${typeof url === 'object' ? url.href : url}>`;
 }
 

--- a/src/messages/formatters.ts
+++ b/src/messages/formatters.ts
@@ -122,7 +122,11 @@ export function hyperlink<C extends string, U extends string>(content: C, url: U
  * @param title The title shown when hovering on the masked link.
  * @returns The formatted content.
  */
-export function hyperlink<C extends string, T extends string>(content: C, url: URL, title: T): `[${C}](${string} ${T})`;
+export function hyperlink<C extends string, T extends string>(
+	content: C,
+	url: URL,
+	title: T,
+): `[${C}](${string} "${T}")`;
 
 /**
  * Formats the content and the URL into a masked URL.
@@ -135,10 +139,10 @@ export function hyperlink<C extends string, U extends string, T extends string>(
 	content: C,
 	url: U,
 	title: T,
-): `[${C}](${U} ${T})`;
+): `[${C}](${U} "${T}")`;
 export function hyperlink(content: string, url: string | URL, title?: string) {
 	// eslint-disable-next-line @typescript-eslint/restrict-template-expressions
-	return title ? `[${content}](${url} ${title})` : `[${content}](${url})`;
+	return title ? `[${content}](${url} "${title}")` : `[${content}](${url})`;
 }
 
 /**

--- a/src/messages/formatters.ts
+++ b/src/messages/formatters.ts
@@ -95,7 +95,7 @@ export function maskedLink<C extends string>(url: C): `<${C}>`;
  */
 export function maskedLink(url: URL): `<${string}>`;
 export function maskedLink(url: string | URL) {
-	return `<${typeof url === 'object' ? url.href : url}>`;
+	return `<${url}>`;
 }
 
 /**
@@ -136,7 +136,6 @@ export function hyperlink<C extends string, U extends string, T extends string>(
 	title: T,
 ): `[${C}](${U} ${T})`;
 export function hyperlink(content: string, url: string | URL, title?: string) {
-	if (typeof url === 'object') url = url.href;
 	return title ? `[${content}](${url} ${title})` : `[${content}](${url})`;
 }
 

--- a/tests/messages.test.ts
+++ b/tests/messages.test.ts
@@ -2,8 +2,10 @@ import {
 	blockQuote,
 	bold,
 	codeBlock,
+	hyperlink,
 	inlineCode,
 	italic,
+	maskLink,
 	quote,
 	strikethrough,
 	time,
@@ -61,6 +63,42 @@ describe('Messages', () => {
 	describe('blockQuote', () => {
 		test('GIVEN "discord.js" THEN returns ">>> discord.js"', () => {
 			expect<'>>> discord.js'>(blockQuote('discord.js')).toBe('>>> discord.js');
+		});
+	});
+
+	describe('maskLink', () => {
+		test('GIVEN "https://discord.js.org" THEN returns "<https://discord.js.org>"', () => {
+			expect<'<https://discord.js.org>'>(maskLink('https://discord.js.org')).toBe('<https://discord.js.org>');
+		});
+
+		test('GIVEN new URL("https://discord.js.org") THEN returns "<https://discord.js.org>"', () => {
+			expect<`<${string}>`>(maskLink(new URL('https://discord.js.org'))).toBe('<https://discord.js.org>');
+		});
+	});
+
+	describe('hyperlink', () => {
+		test('GIVEN content and string URL THEN returns "[content](url)"', () => {
+			expect<'[discord.js](https://discord.js.org)'>(hyperlink('discord.js', 'https://discord.js.org')).toBe(
+				'[discord.js](https://discord.js.org)',
+			);
+		});
+
+		test('GIVEN content and URL THEN returns "[content](url)"', () => {
+			expect<`[discord.js](${string})`>(hyperlink('discord.js', new URL('https://discord.js.org'))).toBe(
+				'[discord.js](https://discord.js.org)',
+			);
+		});
+
+		test('GIVEN content, string URL, and title THEN returns "[content](url title)"', () => {
+			expect<'[discord.js](https://discord.js.org Official Documentation)'>(
+				hyperlink('discord.js', 'https://discord.js.org', 'Official Documentation'),
+			).toBe('[discord.js](https://discord.js.org Official Documentation)');
+		});
+
+		test('GIVEN content, URL, and title THEN returns "[content](url title)"', () => {
+			expect<`[discord.js](${string} Official Documentation)`>(
+				hyperlink('discord.js', new URL('https://discord.js.org'), 'Official Documentation'),
+			).toBe('[discord.js](https://discord.js.org Official Documentation)');
 		});
 	});
 

--- a/tests/messages.test.ts
+++ b/tests/messages.test.ts
@@ -89,16 +89,16 @@ describe('Messages', () => {
 			);
 		});
 
-		test('GIVEN content, string URL, and title THEN returns "[content](url title)"', () => {
-			expect<'[discord.js](https://discord.js.org Official Documentation)'>(
+		test('GIVEN content, string URL, and title THEN returns "[content](url "title")"', () => {
+			expect<'[discord.js](https://discord.js.org "Official Documentation")'>(
 				hyperlink('discord.js', 'https://discord.js.org', 'Official Documentation'),
-			).toBe('[discord.js](https://discord.js.org Official Documentation)');
+			).toBe('[discord.js](https://discord.js.org "Official Documentation")');
 		});
 
-		test('GIVEN content, URL, and title THEN returns "[content](url title)"', () => {
-			expect<`[discord.js](${string} Official Documentation)`>(
+		test('GIVEN content, URL, and title THEN returns "[content](url "title")"', () => {
+			expect<`[discord.js](${string} "Official Documentation")`>(
 				hyperlink('discord.js', new URL('https://discord.js.org'), 'Official Documentation'),
-			).toBe('[discord.js](https://discord.js.org/ Official Documentation)');
+			).toBe('[discord.js](https://discord.js.org/ "Official Documentation")');
 		});
 	});
 

--- a/tests/messages.test.ts
+++ b/tests/messages.test.ts
@@ -5,7 +5,7 @@ import {
 	hyperlink,
 	inlineCode,
 	italic,
-	maskLink,
+	maskedLink,
 	quote,
 	strikethrough,
 	time,
@@ -66,13 +66,13 @@ describe('Messages', () => {
 		});
 	});
 
-	describe('maskLink', () => {
+	describe('maskedLink', () => {
 		test('GIVEN "https://discord.js.org" THEN returns "<https://discord.js.org>"', () => {
-			expect<'<https://discord.js.org>'>(maskLink('https://discord.js.org')).toBe('<https://discord.js.org>');
+			expect<'<https://discord.js.org>'>(maskedLink('https://discord.js.org')).toBe('<https://discord.js.org>');
 		});
 
 		test('GIVEN new URL("https://discord.js.org") THEN returns "<https://discord.js.org>"', () => {
-			expect<`<${string}>`>(maskLink(new URL('https://discord.js.org'))).toBe('<https://discord.js.org>');
+			expect<`<${string}>`>(maskedLink(new URL('https://discord.js.org/'))).toBe('<https://discord.js.org/>');
 		});
 	});
 
@@ -85,7 +85,7 @@ describe('Messages', () => {
 
 		test('GIVEN content and URL THEN returns "[content](url)"', () => {
 			expect<`[discord.js](${string})`>(hyperlink('discord.js', new URL('https://discord.js.org'))).toBe(
-				'[discord.js](https://discord.js.org)',
+				'[discord.js](https://discord.js.org/)',
 			);
 		});
 
@@ -98,7 +98,7 @@ describe('Messages', () => {
 		test('GIVEN content, URL, and title THEN returns "[content](url title)"', () => {
 			expect<`[discord.js](${string} Official Documentation)`>(
 				hyperlink('discord.js', new URL('https://discord.js.org'), 'Official Documentation'),
-			).toBe('[discord.js](https://discord.js.org Official Documentation)');
+			).toBe('[discord.js](https://discord.js.org/ Official Documentation)');
 		});
 	});
 

--- a/tests/messages.test.ts
+++ b/tests/messages.test.ts
@@ -2,10 +2,10 @@ import {
 	blockQuote,
 	bold,
 	codeBlock,
+	hideLinkEmbed,
 	hyperlink,
 	inlineCode,
 	italic,
-	maskedLink,
 	quote,
 	strikethrough,
 	time,
@@ -66,13 +66,13 @@ describe('Messages', () => {
 		});
 	});
 
-	describe('maskedLink', () => {
+	describe('hideLinkEmbed', () => {
 		test('GIVEN "https://discord.js.org" THEN returns "<https://discord.js.org>"', () => {
-			expect<'<https://discord.js.org>'>(maskedLink('https://discord.js.org')).toBe('<https://discord.js.org>');
+			expect<'<https://discord.js.org>'>(hideLinkEmbed('https://discord.js.org')).toBe('<https://discord.js.org>');
 		});
 
 		test('GIVEN new URL("https://discord.js.org") THEN returns "<https://discord.js.org>"', () => {
-			expect<`<${string}>`>(maskedLink(new URL('https://discord.js.org/'))).toBe('<https://discord.js.org/>');
+			expect<`<${string}>`>(hideLinkEmbed(new URL('https://discord.js.org/'))).toBe('<https://discord.js.org/>');
 		});
 	});
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

- Added `maskLink`
- Added `hyperlink`

The "title" bit from `hyperlink` comes from [Digital Guide](https://www.ionos.com/digitalguide/websites/web-development/markdown/).

**Status and versioning classification:**

- This PR changes the library's interface (methods or parameters added)
