### PR TITLE
feat: shrug, tableflip and unflip strings

### DIFF
--- a/src/messages/formatters.ts
+++ b/src/messages/formatters.ts
@@ -226,19 +226,19 @@ export type TimestampStylesString = typeof TimestampStyles[keyof typeof Timestam
 /**
  * An object with all the available faces from Discord's native slash commands
  */
-export const Faces = {
+export enum Faces {
 	/**
 	 * ¯\\_(ツ)_/¯
 	 */
-	Shrug: '¯\\_(ツ)_/¯',
+	Shrug = '¯\\_(ツ)_/¯',
 
 	/**
 	 * (╯°□°）╯︵ ┻━┻
 	 */
-	Tableflip: '(╯°□°）╯︵ ┻━┻',
+	Tableflip = '(╯°□°）╯︵ ┻━┻',
 
 	/**
 	 * ┬─┬ ノ( ゜-゜ノ)
 	 */
-	Unflip: '┬─┬ ノ( ゜-゜ノ)',
-} as const;
+	Unflip = '┬─┬ ノ( ゜-゜ノ)',
+}

--- a/src/messages/formatters.ts
+++ b/src/messages/formatters.ts
@@ -223,19 +223,22 @@ export const TimestampStyles = {
  */
 export type TimestampStylesString = typeof TimestampStyles[keyof typeof TimestampStyles];
 
+/**
+ * An object with all the available faces from Discord's native slash commands
+ */
 export const Faces = {
 	/**
 	 * ¯\\_(ツ)_/¯
 	 */
-	shrug: '¯\\_(ツ)_/¯',
+	Shrug: '¯\\_(ツ)_/¯',
 
 	/**
 	 * (╯°□°）╯︵ ┻━┻
 	 */
-	tableflip: '(╯°□°）╯︵ ┻━┻',
+	Tableflip: '(╯°□°）╯︵ ┻━┻',
 
 	/**
 	 * ┬─┬ ノ( ゜-゜ノ)
 	 */
-	unflip: '┬─┬ ノ( ゜-゜ノ)',
-};
+	Unflip: '┬─┬ ノ( ゜-゜ノ)',
+} as const;

--- a/src/messages/formatters.ts
+++ b/src/messages/formatters.ts
@@ -224,7 +224,7 @@ export const TimestampStyles = {
 export type TimestampStylesString = typeof TimestampStyles[keyof typeof TimestampStyles];
 
 /**
- * An object with all the available faces from Discord's native slash commands
+ * An enum with all the available faces from Discord's native slash commands
  */
 export enum Faces {
 	/**

--- a/src/messages/formatters.ts
+++ b/src/messages/formatters.ts
@@ -222,3 +222,20 @@ export const TimestampStyles = {
  * The possible values, see {@link TimestampStyles} for more information.
  */
 export type TimestampStylesString = typeof TimestampStyles[keyof typeof TimestampStyles];
+
+export const Faces = {
+	/**
+	 * ¯\\_(ツ)_/¯
+	 */
+	shrug: '¯\\_(ツ)_/¯',
+
+	/**
+	 * (╯°□°）╯︵ ┻━┻
+	 */
+	tableflip: '(╯°□°）╯︵ ┻━┻',
+
+	/**
+	 * ┬─┬ ノ( ゜-゜ノ)
+	 */
+	unflip: '┬─┬ ノ( ゜-゜ノ)',
+};

--- a/tests/messages.test.ts
+++ b/tests/messages.test.ts
@@ -2,6 +2,7 @@ import {
 	blockQuote,
 	bold,
 	codeBlock,
+	Faces,
 	hideLinkEmbed,
 	hyperlink,
 	inlineCode,
@@ -134,6 +135,20 @@ describe('Messages', () => {
 
 		test('GIVEN a date and a format from enum THEN returns "<t:${time}:${style}>"', () => {
 			expect<'<t:1867424897:R>'>(time(1867424897, TimestampStyles.RelativeTime)).toBe('<t:1867424897:R>');
+		});
+	});
+
+	describe('Faces', () => {
+		test('it should return "¯\\_(ツ)_/¯"', () => {
+			expect<'¯\\_(ツ)_/¯'>(Faces.Shrug).toBe('¯\\_(ツ)_/¯');
+		});
+
+		test('it should return "(╯°□°）╯︵ ┻━┻"', () => {
+			expect<'(╯°□°）╯︵ ┻━┻'>(Faces.Tableflip).toBe('(╯°□°）╯︵ ┻━┻');
+		});
+
+		test('it should return "┬─┬ ノ( ゜-゜ノ)"', () => {
+			expect<'┬─┬ ノ( ゜-゜ノ)'>(Faces.Unflip).toBe('┬─┬ ノ( ゜-゜ノ)');
 		});
 	});
 });

--- a/tests/messages.test.ts
+++ b/tests/messages.test.ts
@@ -139,15 +139,15 @@ describe('Messages', () => {
 	});
 
 	describe('Faces', () => {
-		test('it should return "¯\\_(ツ)_/¯"', () => {
+		test('GIVEN Faces.Shrug THEN returns "¯\\_(ツ)_/¯"', () => {
 			expect<'¯\\_(ツ)_/¯'>(Faces.Shrug).toBe('¯\\_(ツ)_/¯');
 		});
 
-		test('it should return "(╯°□°）╯︵ ┻━┻"', () => {
+		test('GIVEN Faces.Tableflip THEN returns "(╯°□°）╯︵ ┻━┻"', () => {
 			expect<'(╯°□°）╯︵ ┻━┻'>(Faces.Tableflip).toBe('(╯°□°）╯︵ ┻━┻');
 		});
 
-		test('it should return "┬─┬ ノ( ゜-゜ノ)"', () => {
+		test('GIVEN Faces.Unflip THEN returns "┬─┬ ノ( ゜-゜ノ)"', () => {
 			expect<'┬─┬ ノ( ゜-゜ノ)'>(Faces.Unflip).toBe('┬─┬ ノ( ゜-゜ノ)');
 		});
 	});


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This PR adds an object with all 3 unicode emojis supported by Discord's native slash commands: shrug, tableflip and unflip

**Status and versioning classification:**
- This PR changes the library's interface (methods or parameters added)

<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
