### PR TITLE
feat(formatters): mentions

### DIFF
--- a/src/messages/formatters.ts
+++ b/src/messages/formatters.ts
@@ -151,8 +151,8 @@ export function hyperlink(content: string, url: string | URL, title?: string) {
  * @param userId The user ID to format.
  * @returns The formatted user mention.
  */
-export function userMention<C extends Snowflake>(userId: C): `<@!${C}>` {
-	return `<@!${userId}>`;
+export function userMention<C extends Snowflake>(userId: C): `<@${C}>` {
+	return `<@${userId}>`;
 }
 
 /**
@@ -160,8 +160,8 @@ export function userMention<C extends Snowflake>(userId: C): `<@!${C}>` {
  * @param memberId The user ID to format.
  * @returns The formatted member-nickname mention.
  */
-export function memberNicknameMention<C extends Snowflake>(memberId: C): `<@${C}>` {
-	return `<@${memberId}>`;
+export function memberNicknameMention<C extends Snowflake>(memberId: C): `<@!${C}>` {
+	return `<@!${memberId}>`;
 }
 
 /**

--- a/src/messages/formatters.ts
+++ b/src/messages/formatters.ts
@@ -174,7 +174,7 @@ export function channelMention<C extends Snowflake>(channelId: C): `<#${C}>` {
 }
 
 /**
- * Formats the channel ID into a role mention.
+ * Formats the role ID into a role mention.
  * @param roleId The role ID to format.
  * @returns The formatted role mention.
  */

--- a/src/messages/formatters.ts
+++ b/src/messages/formatters.ts
@@ -156,6 +156,15 @@ export function userMention<C extends Snowflake>(userId: C): `<@!${C}>` {
 }
 
 /**
+ * Formats the user ID into a member-nickname mention.
+ * @param memberId The user ID to format.
+ * @returns The formatted member-nickname mention.
+ */
+export function memberNicknameMention<C extends Snowflake>(memberId: C): `<@${C}>` {
+	return `<@${memberId}>`;
+}
+
+/**
  * Formats the channel ID into a channel mention.
  * @param channelId The channel ID to format.
  * @returns The formatted channel mention.

--- a/src/messages/formatters.ts
+++ b/src/messages/formatters.ts
@@ -146,6 +146,33 @@ export function hyperlink(content: string, url: string | URL, title?: string) {
 }
 
 /**
+ * Formats the user ID into a user mention.
+ * @param userId The user ID to format.
+ * @returns The formatted user mention.
+ */
+export function userMention<C extends string>(userId: C): `<@!${C}>` {
+	return `<@!${userId}>`;
+}
+
+/**
+ * Formats the channel ID into a channel mention.
+ * @param channelId The channel ID to format.
+ * @returns The formatted channel mention.
+ */
+ export function channelMention<C extends string>(channelId: C): `<#${C}>` {
+	return `<#${channelId}>`;
+}
+
+/**
+ * Formats the channel ID into a role mention.
+ * @param roleId The role ID to format.
+ * @returns The formatted role mention.
+ */
+ export function roleMention<C extends string>(roleId: C): `<@&${C}>` {
+	return `<@&${roleId}>`;
+}
+
+/**
  * Formats a date into a short date-time string.
  * @param date The date to format, defaults to the current time.
  */

--- a/src/messages/formatters.ts
+++ b/src/messages/formatters.ts
@@ -1,4 +1,4 @@
-import type { Snowflake } from 'discord-api-types';
+import type { Snowflake } from 'discord-api-types/globals';
 import type { URL } from 'url';
 
 /**

--- a/src/messages/formatters.ts
+++ b/src/messages/formatters.ts
@@ -1,3 +1,4 @@
+import type { Snowflake } from 'discord-api-types';
 import type { URL } from 'url';
 
 /**
@@ -150,7 +151,7 @@ export function hyperlink(content: string, url: string | URL, title?: string) {
  * @param userId The user ID to format.
  * @returns The formatted user mention.
  */
-export function userMention<C extends string>(userId: C): `<@!${C}>` {
+export function userMention<C extends Snowflake>(userId: C): `<@!${C}>` {
 	return `<@!${userId}>`;
 }
 
@@ -159,7 +160,7 @@ export function userMention<C extends string>(userId: C): `<@!${C}>` {
  * @param channelId The channel ID to format.
  * @returns The formatted channel mention.
  */
- export function channelMention<C extends string>(channelId: C): `<#${C}>` {
+export function channelMention<C extends Snowflake>(channelId: C): `<#${C}>` {
 	return `<#${channelId}>`;
 }
 
@@ -168,7 +169,7 @@ export function userMention<C extends string>(userId: C): `<@!${C}>` {
  * @param roleId The role ID to format.
  * @returns The formatted role mention.
  */
- export function roleMention<C extends string>(roleId: C): `<@&${C}>` {
+export function roleMention<C extends Snowflake>(roleId: C): `<@&${C}>` {
 	return `<@&${roleId}>`;
 }
 

--- a/tests/messages.test.ts
+++ b/tests/messages.test.ts
@@ -1,6 +1,7 @@
 import {
 	blockQuote,
 	bold,
+	channelMention,
 	codeBlock,
 	Faces,
 	hideLinkEmbed,
@@ -107,13 +108,25 @@ describe('Messages', () => {
 
 	describe('userMention', () => {
 		test('GIVEN userId THEN returns "<@[userId]>"', () => {
-			expect<'<@139836912335716352>'>(userMention('139836912335716352')).toBe('<@139836912335716352>');
+			expect(userMention('139836912335716352')).toBe('<@139836912335716352>');
 		});
 	});
 
 	describe('memberNicknameMention', () => {
 		test('GIVEN memberId THEN returns "<@![memberId]>"', () => {
-			expect<'<@!139836912335716352>'>(memberNicknameMention('139836912335716352')).toBe('<@!139836912335716352>');
+			expect(memberNicknameMention('139836912335716352')).toBe('<@!139836912335716352>');
+		});
+	});
+
+	describe('channelMention', () => {
+		test('GIVEN channelId THEN returns "<#[channelId]>"', () => {
+			expect(channelMention('829924760309334087')).toBe('<#829924760309334087>');
+		});
+	});
+
+	describe('roleMention', () => {
+		test('GIVEN roleId THEN returns "<&[roleId]>"', () => {
+			expect(channelMention('815434166602170409')).toBe('<@&815434166602170409>');
 		});
 	});
 

--- a/tests/messages.test.ts
+++ b/tests/messages.test.ts
@@ -10,6 +10,7 @@ import {
 	italic,
 	memberNicknameMention,
 	quote,
+	roleMention,
 	strikethrough,
 	time,
 	TimestampStyles,
@@ -126,7 +127,7 @@ describe('Messages', () => {
 
 	describe('roleMention', () => {
 		test('GIVEN roleId THEN returns "<&[roleId]>"', () => {
-			expect(channelMention('815434166602170409')).toBe('<@&815434166602170409>');
+			expect(roleMention('815434166602170409')).toBe('<@&815434166602170409>');
 		});
 	});
 

--- a/tests/messages.test.ts
+++ b/tests/messages.test.ts
@@ -7,11 +7,13 @@ import {
 	hyperlink,
 	inlineCode,
 	italic,
+	memberNicknameMention,
 	quote,
 	strikethrough,
 	time,
 	TimestampStyles,
 	underscore,
+	userMention,
 } from '../src';
 
 describe('Messages', () => {
@@ -100,6 +102,18 @@ describe('Messages', () => {
 			expect<`[discord.js](${string} "Official Documentation")`>(
 				hyperlink('discord.js', new URL('https://discord.js.org'), 'Official Documentation'),
 			).toBe('[discord.js](https://discord.js.org/ "Official Documentation")');
+		});
+	});
+
+	describe('userMention', () => {
+		test('GIVEN userId THEN returns "<@[userId]>"', () => {
+			expect<'<@139836912335716352>'>(userMention('139836912335716352')).toBe('<@139836912335716352>');
+		});
+	});
+
+	describe('memberNicknameMention', () => {
+		test('GIVEN memberId THEN returns "<@![memberId]>"', () => {
+			expect<'<@!139836912335716352>'>(memberNicknameMention('139836912335716352')).toBe('<@!139836912335716352>');
 		});
 	});
 

--- a/tests/messages.test.ts
+++ b/tests/messages.test.ts
@@ -107,27 +107,29 @@ describe('Messages', () => {
 		});
 	});
 
-	describe('userMention', () => {
-		test('GIVEN userId THEN returns "<@[userId]>"', () => {
-			expect(userMention('139836912335716352')).toBe('<@139836912335716352>');
+	describe('Mentions', () => {
+		describe('userMention', () => {
+			test('GIVEN userId THEN returns "<@[userId]>"', () => {
+				expect(userMention('139836912335716352')).toBe('<@139836912335716352>');
+			});
 		});
-	});
 
-	describe('memberNicknameMention', () => {
-		test('GIVEN memberId THEN returns "<@![memberId]>"', () => {
-			expect(memberNicknameMention('139836912335716352')).toBe('<@!139836912335716352>');
+		describe('memberNicknameMention', () => {
+			test('GIVEN memberId THEN returns "<@![memberId]>"', () => {
+				expect(memberNicknameMention('139836912335716352')).toBe('<@!139836912335716352>');
+			});
 		});
-	});
 
-	describe('channelMention', () => {
-		test('GIVEN channelId THEN returns "<#[channelId]>"', () => {
-			expect(channelMention('829924760309334087')).toBe('<#829924760309334087>');
+		describe('channelMention', () => {
+			test('GIVEN channelId THEN returns "<#[channelId]>"', () => {
+				expect(channelMention('829924760309334087')).toBe('<#829924760309334087>');
+			});
 		});
-	});
 
-	describe('roleMention', () => {
-		test('GIVEN roleId THEN returns "<&[roleId]>"', () => {
-			expect(roleMention('815434166602170409')).toBe('<@&815434166602170409>');
+		describe('roleMention', () => {
+			test('GIVEN roleId THEN returns "<&[roleId]>"', () => {
+				expect(roleMention('815434166602170409')).toBe('<@&815434166602170409>');
+			});
 		});
 	});
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This adds new mentions formatters to the library. You can now use `userMention()`, `roleMention()`, and `channelMention()`.


**Status and versioning classification:**
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- Code changes have been tested against the Discord API, or there are no code changes

<!--
Please move lines that apply to you out of the comment:
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->