### PR TITLE
fix(Shrug): Update comment

### DIFF
--- a/src/messages/formatters.ts
+++ b/src/messages/formatters.ts
@@ -228,7 +228,7 @@ export type TimestampStylesString = typeof TimestampStyles[keyof typeof Timestam
  */
 export enum Faces {
 	/**
-	 * ¯\\_(ツ)_/¯
+	 * ¯\\_(ツ)\\_/¯
 	 */
 	Shrug = '¯\\_(ツ)\\_/¯',
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

The jsdoc comment before the [`Shrug`](https://github.com/discordjs/builders/blob/6aa3af07b0ee342fff91f080914bb12b3ab773f8/src/messages/formatters.ts#L231) value was not updated in #13. Let's fix it!

Reference: https://github.com/discordjs/builders/pull/13#discussion_r671382602

**Status and versioning classification:**

Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR **only** includes non-code changes, like changes to documentation, README, etc.