### PR TITLE
chore: update discord-api-types to 0.19.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@sindresorhus/is": "^4.0.1",
-				"discord-api-types": "^0.18.1",
+				"discord-api-types": "^0.19.0",
 				"ow": "^0.26.0",
 				"ts-mixer": "^5.4.1",
 				"tslib": "^2.3.0"
@@ -4060,9 +4060,9 @@
 			}
 		},
 		"node_modules/discord-api-types": {
-			"version": "0.18.1",
-			"resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.18.1.tgz",
-			"integrity": "sha512-hNC38R9ZF4uaujaZQtQfm5CdQO58uhdkoHQAVvMfIL0LgOSZeW575W8H6upngQOuoxWd8tiRII3LLJm9zuQKYg==",
+			"version": "0.19.0",
+			"resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.19.0.tgz",
+			"integrity": "sha512-t2HKLd43Lbe+rf+ffYfKVv9Kk5f6p7sFqvO6CMV55ZB0PgZv8WigCkt9FoJciYo5S3Q6CGYK+WnE/ZG+6vkBDQ==",
 			"engines": {
 				"node": ">=12"
 			}
@@ -13294,9 +13294,9 @@
 			}
 		},
 		"discord-api-types": {
-			"version": "0.18.1",
-			"resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.18.1.tgz",
-			"integrity": "sha512-hNC38R9ZF4uaujaZQtQfm5CdQO58uhdkoHQAVvMfIL0LgOSZeW575W8H6upngQOuoxWd8tiRII3LLJm9zuQKYg=="
+			"version": "0.19.0",
+			"resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.19.0.tgz",
+			"integrity": "sha512-t2HKLd43Lbe+rf+ffYfKVv9Kk5f6p7sFqvO6CMV55ZB0PgZv8WigCkt9FoJciYo5S3Q6CGYK+WnE/ZG+6vkBDQ=="
 		},
 		"doctrine": {
 			"version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
 	"homepage": "https://github.com/discordjs/builders#readme",
 	"dependencies": {
 		"@sindresorhus/is": "^4.0.1",
-		"discord-api-types": "^0.18.1",
+		"discord-api-types": "^0.19.0",
 		"ow": "^0.26.0",
 		"ts-mixer": "^5.4.1",
 		"tslib": "^2.3.0"

--- a/src/interactions/slashCommands/Assertions.ts
+++ b/src/interactions/slashCommands/Assertions.ts
@@ -1,5 +1,5 @@
 import is from '@sindresorhus/is';
-import type { APIApplicationCommandOptionChoice } from 'discord-api-types/v8';
+import type { APIApplicationCommandOptionChoice } from 'discord-api-types/v9';
 import ow from 'ow';
 import type { SlashCommandOptionBase } from './mixins/CommandOptionBase';
 import type { ToAPIApplicationCommandOptions } from './SlashCommandBuilder';

--- a/src/interactions/slashCommands/SlashCommandBuilder.ts
+++ b/src/interactions/slashCommands/SlashCommandBuilder.ts
@@ -1,4 +1,4 @@
-import type { APIApplicationCommandOption } from 'discord-api-types/v8';
+import type { APIApplicationCommandOption } from 'discord-api-types/v9';
 import { mix } from 'ts-mixer';
 import { assertReturnOfBuilder, validateMaxOptionsLength, validateRequiredParameters } from './Assertions';
 import { SharedNameAndDescription } from './mixins/NameAndDescription';

--- a/src/interactions/slashCommands/SlashCommandSubCommands.ts
+++ b/src/interactions/slashCommands/SlashCommandSubCommands.ts
@@ -1,4 +1,4 @@
-import { ApplicationCommandOptionType } from 'discord-api-types/v8';
+import { ApplicationCommandOptionType } from 'discord-api-types/v9';
 import { mix } from 'ts-mixer';
 import { assertReturnOfBuilder, validateMaxOptionsLength, validateRequiredParameters } from './Assertions';
 import { SharedSlashCommandOptions } from './mixins/CommandOptions';
@@ -55,7 +55,7 @@ export class SlashCommandSubCommandGroupBuilder implements ToAPIApplicationComma
 	public toJSON() {
 		validateRequiredParameters(this.name, this.description, this.options);
 		return {
-			type: ApplicationCommandOptionType.SUB_COMMAND_GROUP,
+			type: ApplicationCommandOptionType.SubCommandGroup,
 			name: this.name,
 			description: this.description,
 			options: this.options.map((option) => option.toJSON()),
@@ -90,7 +90,7 @@ export class SlashCommandSubCommandBuilder implements ToAPIApplicationCommandOpt
 	public toJSON() {
 		validateRequiredParameters(this.name, this.description, this.options);
 		return {
-			type: ApplicationCommandOptionType.SUB_COMMAND,
+			type: ApplicationCommandOptionType.SubCommand,
 			name: this.name,
 			description: this.description,
 			options: this.options.map((option) => option.toJSON()),

--- a/src/interactions/slashCommands/mixins/CommandOptionBase.ts
+++ b/src/interactions/slashCommands/mixins/CommandOptionBase.ts
@@ -1,4 +1,4 @@
-import type { ApplicationCommandOptionType } from 'discord-api-types/v8';
+import type { ApplicationCommandOptionType } from 'discord-api-types/v9';
 import ow from 'ow';
 import { validateRequiredParameters } from '../Assertions';
 import type { ToAPIApplicationCommandOptions } from '../SlashCommandBuilder';

--- a/src/interactions/slashCommands/mixins/CommandOptionWithChoices.ts
+++ b/src/interactions/slashCommands/mixins/CommandOptionWithChoices.ts
@@ -1,4 +1,4 @@
-import { APIApplicationCommandOptionChoice, ApplicationCommandOptionType } from 'discord-api-types/v8';
+import { APIApplicationCommandOptionChoice, ApplicationCommandOptionType } from 'discord-api-types/v9';
 import ow, { Predicate } from 'ow';
 import { validateMaxChoicesLength } from '../Assertions';
 import type { ToAPIApplicationCommandOptions } from '../SlashCommandBuilder';
@@ -31,12 +31,12 @@ export abstract class ApplicationCommandOptionWithChoicesBase<T extends string |
 		// Validate name
 		ow(
 			name,
-			`${this.type === ApplicationCommandOptionType.STRING ? 'string' : 'integer'} choice name`,
+			`${this.type === ApplicationCommandOptionType.String ? 'string' : 'integer'} choice name`,
 			stringPredicate,
 		);
 
 		// Validate the value
-		if (this.type === ApplicationCommandOptionType.STRING) ow(value, 'string choice value', stringPredicate);
+		if (this.type === ApplicationCommandOptionType.String) ow(value, 'string choice value', stringPredicate);
 		else ow(value, 'integer choice value', integerPredicate);
 
 		this.choices.push({ name, value });
@@ -51,7 +51,7 @@ export abstract class ApplicationCommandOptionWithChoicesBase<T extends string |
 	public addChoices(choices: [name: string, value: T][]) {
 		ow(
 			choices,
-			`${this.type === ApplicationCommandOptionType.STRING ? 'string' : 'integer'} choices`,
+			`${this.type === ApplicationCommandOptionType.String ? 'string' : 'integer'} choices`,
 			choicesPredicate,
 		);
 

--- a/src/interactions/slashCommands/options/boolean.ts
+++ b/src/interactions/slashCommands/options/boolean.ts
@@ -1,10 +1,10 @@
-import { ApplicationCommandOptionType } from 'discord-api-types/v8';
+import { ApplicationCommandOptionType } from 'discord-api-types/v9';
 import { SlashCommandOptionBase } from '../mixins/CommandOptionBase';
 
 export class SlashCommandBooleanOption extends SlashCommandOptionBase {
-	public override readonly type = ApplicationCommandOptionType.BOOLEAN as const;
+	public override readonly type = ApplicationCommandOptionType.Boolean as const;
 
 	public constructor() {
-		super(ApplicationCommandOptionType.BOOLEAN);
+		super(ApplicationCommandOptionType.Boolean);
 	}
 }

--- a/src/interactions/slashCommands/options/channel.ts
+++ b/src/interactions/slashCommands/options/channel.ts
@@ -1,10 +1,10 @@
-import { ApplicationCommandOptionType } from 'discord-api-types/v8';
+import { ApplicationCommandOptionType } from 'discord-api-types/v9';
 import { SlashCommandOptionBase } from '../mixins/CommandOptionBase';
 
 export class SlashCommandChannelOption extends SlashCommandOptionBase {
-	public override readonly type = ApplicationCommandOptionType.CHANNEL as const;
+	public override readonly type = ApplicationCommandOptionType.Channel as const;
 
 	public constructor() {
-		super(ApplicationCommandOptionType.CHANNEL);
+		super(ApplicationCommandOptionType.Channel);
 	}
 }

--- a/src/interactions/slashCommands/options/integer.ts
+++ b/src/interactions/slashCommands/options/integer.ts
@@ -1,10 +1,10 @@
-import { ApplicationCommandOptionType } from 'discord-api-types/v8';
+import { ApplicationCommandOptionType } from 'discord-api-types/v9';
 import { ApplicationCommandOptionWithChoicesBase } from '../mixins/CommandOptionWithChoices';
 
 export class SlashCommandIntegerOption extends ApplicationCommandOptionWithChoicesBase<number> {
-	public override readonly type = ApplicationCommandOptionType.INTEGER as const;
+	public override readonly type = ApplicationCommandOptionType.Integer as const;
 
 	public constructor() {
-		super(ApplicationCommandOptionType.INTEGER);
+		super(ApplicationCommandOptionType.Integer);
 	}
 }

--- a/src/interactions/slashCommands/options/mentionable.ts
+++ b/src/interactions/slashCommands/options/mentionable.ts
@@ -1,10 +1,10 @@
-import { ApplicationCommandOptionType } from 'discord-api-types/v8';
+import { ApplicationCommandOptionType } from 'discord-api-types/v9';
 import { SlashCommandOptionBase } from '../mixins/CommandOptionBase';
 
 export class SlashCommandMentionableOption extends SlashCommandOptionBase {
-	public override readonly type = ApplicationCommandOptionType.MENTIONABLE as const;
+	public override readonly type = ApplicationCommandOptionType.Mentionable as const;
 
 	public constructor() {
-		super(ApplicationCommandOptionType.MENTIONABLE);
+		super(ApplicationCommandOptionType.Mentionable);
 	}
 }

--- a/src/interactions/slashCommands/options/role.ts
+++ b/src/interactions/slashCommands/options/role.ts
@@ -1,10 +1,10 @@
-import { ApplicationCommandOptionType } from 'discord-api-types/v8';
+import { ApplicationCommandOptionType } from 'discord-api-types/v9';
 import { SlashCommandOptionBase } from '../mixins/CommandOptionBase';
 
 export class SlashCommandRoleOption extends SlashCommandOptionBase {
-	public override readonly type = ApplicationCommandOptionType.ROLE as const;
+	public override readonly type = ApplicationCommandOptionType.Role as const;
 
 	public constructor() {
-		super(ApplicationCommandOptionType.ROLE);
+		super(ApplicationCommandOptionType.Role);
 	}
 }

--- a/src/interactions/slashCommands/options/string.ts
+++ b/src/interactions/slashCommands/options/string.ts
@@ -1,10 +1,10 @@
-import { ApplicationCommandOptionType } from 'discord-api-types/v8';
+import { ApplicationCommandOptionType } from 'discord-api-types/v9';
 import { ApplicationCommandOptionWithChoicesBase } from '../mixins/CommandOptionWithChoices';
 
 export class SlashCommandStringOption extends ApplicationCommandOptionWithChoicesBase<string> {
-	public override readonly type = ApplicationCommandOptionType.STRING as const;
+	public override readonly type = ApplicationCommandOptionType.String as const;
 
 	public constructor() {
-		super(ApplicationCommandOptionType.STRING);
+		super(ApplicationCommandOptionType.String);
 	}
 }

--- a/src/interactions/slashCommands/options/user.ts
+++ b/src/interactions/slashCommands/options/user.ts
@@ -1,10 +1,10 @@
-import { ApplicationCommandOptionType } from 'discord-api-types/v8';
+import { ApplicationCommandOptionType } from 'discord-api-types/v9';
 import { SlashCommandOptionBase } from '../mixins/CommandOptionBase';
 
 export class SlashCommandUserOption extends SlashCommandOptionBase {
-	public override readonly type = ApplicationCommandOptionType.USER as const;
+	public override readonly type = ApplicationCommandOptionType.User as const;
 
 	public constructor() {
-		super(ApplicationCommandOptionType.USER);
+		super(ApplicationCommandOptionType.User);
 	}
 }


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Brings discord-api-types up to date

**Status and versioning classification:**

- Code changes have been tested against the Discord API, or there are no code changes