### PR TITLE
feat(Formatters): Add a spoiler function

### DIFF
--- a/src/messages/formatters.ts
+++ b/src/messages/formatters.ts
@@ -147,6 +147,13 @@ export function hyperlink(content: string, url: string | URL, title?: string) {
 }
 
 /**
+ * Wraps the content inside spoiler (hidden text).
+ * @param content The content to wrap.
+ * @returns The formatted content.
+ */
+export function spoiler<C extends string>(content: C): `||${C}||`;
+
+/**
  * Formats the user ID into a user mention.
  * @param userId The user ID to format.
  * @returns The formatted user mention.

--- a/src/messages/formatters.ts
+++ b/src/messages/formatters.ts
@@ -151,7 +151,9 @@ export function hyperlink(content: string, url: string | URL, title?: string) {
  * @param content The content to wrap.
  * @returns The formatted content.
  */
-export function spoiler<C extends string>(content: C): `||${C}||`;
+export function spoiler<C extends string>(content: C): `||${C}||` {
+	return `||${content}||`;
+}
 
 /**
  * Formats the user ID into a user mention.

--- a/tests/messages.test.ts
+++ b/tests/messages.test.ts
@@ -6,6 +6,7 @@ import {
 	Faces,
 	hideLinkEmbed,
 	hyperlink,
+	spoiler,
 	inlineCode,
 	italic,
 	memberNicknameMention,
@@ -104,6 +105,12 @@ describe('Messages', () => {
 			expect<`[discord.js](${string} "Official Documentation")`>(
 				hyperlink('discord.js', new URL('https://discord.js.org'), 'Official Documentation'),
 			).toBe('[discord.js](https://discord.js.org/ "Official Documentation")');
+		});
+	});
+	
+	describe('spoiler', () => {
+		test('GIVEN "discord.js" THEN returns "||discord.js||"', () => {
+			expect<'||discord.js||'>(spoiler('discord.js')).toBe('||discord.js||');
 		});
 	});
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This PR adds a `spoiler` function to text formatters. If it gets accepted, I'll add it to https://github.com/discordjs/discord.js/blob/master/src/util/Formatters.js

**Status and versioning classification:**

- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
