### PR TITLE
feat(SlashCommands): add number option type

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ export * from './interactions/slashCommands/options/boolean';
 export * from './interactions/slashCommands/options/channel';
 export * from './interactions/slashCommands/options/integer';
 export * from './interactions/slashCommands/options/mentionable';
+export * from './interactions/slashCommands/options/number';
 export * from './interactions/slashCommands/options/role';
 export * from './interactions/slashCommands/options/string';
 export * from './interactions/slashCommands/options/user';

--- a/src/interactions/slashCommands/mixins/CommandOptionWithChoices.ts
+++ b/src/interactions/slashCommands/mixins/CommandOptionWithChoices.ts
@@ -29,26 +29,11 @@ export abstract class ApplicationCommandOptionWithChoicesBase<T extends string |
 		validateMaxChoicesLength(this.choices);
 
 		// Validate name
-		ow(
-			name,
-			`${
-				this.type === ApplicationCommandOptionType.String
-					? 'string'
-					: this.type === ApplicationCommandOptionType.Integer
-					? 'integer'
-					: 'number'
-			} choice name`,
-			stringPredicate,
-		);
+		ow(name, `${ApplicationCommandOptionTypeNames[this.type]} choice name`, stringPredicate);
 
 		// Validate the value
 		if (this.type === ApplicationCommandOptionType.String) ow(value, 'string choice value', stringPredicate);
-		else
-			ow(
-				value,
-				`${this.type === ApplicationCommandOptionType.Integer ? 'integer' : 'number'} choice value`,
-				integerPredicate,
-			);
+		else ow(value, `${ApplicationCommandOptionTypeNames[this.type]} choice value`, integerPredicate);
 
 		this.choices.push({ name, value });
 
@@ -60,17 +45,7 @@ export abstract class ApplicationCommandOptionWithChoicesBase<T extends string |
 	 * @param choices The choices to add
 	 */
 	public addChoices(choices: [name: string, value: T][]) {
-		ow(
-			choices,
-			`${
-				this.type === ApplicationCommandOptionType.String
-					? 'string'
-					: this.type === ApplicationCommandOptionType.Integer
-					? 'integer'
-					: 'number'
-			} choices`,
-			choicesPredicate,
-		);
+		ow(choices, `${ApplicationCommandOptionTypeNames[this.type]} choices`, choicesPredicate);
 
 		for (const [label, value] of choices) this.addChoice(label, value);
 		return this;
@@ -83,3 +58,16 @@ export abstract class ApplicationCommandOptionWithChoicesBase<T extends string |
 		};
 	}
 }
+
+const ApplicationCommandOptionTypeNames = {
+	[ApplicationCommandOptionType.Subcommand]: 'subcommand',
+	[ApplicationCommandOptionType.SubcommandGroup]: 'subcommand group',
+	[ApplicationCommandOptionType.String]: 'string',
+	[ApplicationCommandOptionType.Integer]: 'integer',
+	[ApplicationCommandOptionType.Boolean]: 'boolean',
+	[ApplicationCommandOptionType.User]: 'user',
+	[ApplicationCommandOptionType.Channel]: 'channel',
+	[ApplicationCommandOptionType.Role]: 'role',
+	[ApplicationCommandOptionType.Mentionable]: 'mentionable',
+	[ApplicationCommandOptionType.Number]: 'number',
+} as const;

--- a/src/interactions/slashCommands/mixins/CommandOptionWithChoices.ts
+++ b/src/interactions/slashCommands/mixins/CommandOptionWithChoices.ts
@@ -31,13 +31,20 @@ export abstract class ApplicationCommandOptionWithChoicesBase<T extends string |
 		// Validate name
 		ow(
 			name,
-			`${this.type === ApplicationCommandOptionType.String ? 'string' : 'integer'} choice name`,
+			`${
+				this.type === ApplicationCommandOptionType.String
+					? 'string'
+					: this.type === ApplicationCommandOptionType.Integer
+					? 'integer'
+					: 'number'
+			} choice name`,
 			stringPredicate,
 		);
 
 		// Validate the value
 		if (this.type === ApplicationCommandOptionType.String) ow(value, 'string choice value', stringPredicate);
-		else ow(value, 'integer choice value', integerPredicate);
+		else if (this.type === ApplicationCommandOptionType.Integer) ow(value, 'integer choice value', integerPredicate);
+		else ow(value, 'number choice value', integerPredicate);
 
 		this.choices.push({ name, value });
 
@@ -51,7 +58,13 @@ export abstract class ApplicationCommandOptionWithChoicesBase<T extends string |
 	public addChoices(choices: [name: string, value: T][]) {
 		ow(
 			choices,
-			`${this.type === ApplicationCommandOptionType.String ? 'string' : 'integer'} choices`,
+			`${
+				this.type === ApplicationCommandOptionType.String
+					? 'string'
+					: this.type === ApplicationCommandOptionType.Integer
+					? 'integer'
+					: 'number'
+			} choices`,
 			choicesPredicate,
 		);
 

--- a/src/interactions/slashCommands/mixins/CommandOptionWithChoices.ts
+++ b/src/interactions/slashCommands/mixins/CommandOptionWithChoices.ts
@@ -43,8 +43,12 @@ export abstract class ApplicationCommandOptionWithChoicesBase<T extends string |
 
 		// Validate the value
 		if (this.type === ApplicationCommandOptionType.String) ow(value, 'string choice value', stringPredicate);
-		else if (this.type === ApplicationCommandOptionType.Integer) ow(value, 'integer choice value', integerPredicate);
-		else ow(value, 'number choice value', integerPredicate);
+		else
+			ow(
+				value,
+				`${this.type === ApplicationCommandOptionType.Integer ? 'integer' : 'number'} choice value`,
+				integerPredicate,
+			);
 
 		this.choices.push({ name, value });
 

--- a/src/interactions/slashCommands/mixins/CommandOptions.ts
+++ b/src/interactions/slashCommands/mixins/CommandOptions.ts
@@ -4,6 +4,7 @@ import { SlashCommandBooleanOption } from '../options/boolean';
 import { SlashCommandChannelOption } from '../options/channel';
 import { SlashCommandIntegerOption } from '../options/integer';
 import { SlashCommandMentionableOption } from '../options/mentionable';
+import { SlashCommandNumberOption } from '../options/number';
 import { SlashCommandRoleOption } from '../options/role';
 import { SlashCommandStringOption } from '../options/string';
 import { SlashCommandUserOption } from '../options/user';
@@ -76,6 +77,16 @@ export class SharedSlashCommandOptions<ShouldOmitSubcommandFunctions = true> {
 		input: SlashCommandIntegerOption | ((builder: SlashCommandIntegerOption) => SlashCommandIntegerOption),
 	) {
 		return this._sharedAddOptionMethod(input, SlashCommandIntegerOption);
+	}
+
+	/**
+	 * Adds a number option
+	 * @param input A function that returns an option builder, or an already built builder
+	 */
+	public addNumberOption(
+		input: SlashCommandNumberOption | ((builder: SlashCommandNumberOption) => SlashCommandNumberOption),
+	) {
+		return this._sharedAddOptionMethod(input, SlashCommandNumberOption);
 	}
 
 	private _sharedAddOptionMethod<T extends SlashCommandOptionBase>(

--- a/src/interactions/slashCommands/options/number.ts
+++ b/src/interactions/slashCommands/options/number.ts
@@ -1,0 +1,10 @@
+import { ApplicationCommandOptionType } from 'discord-api-types/v9';
+import { ApplicationCommandOptionWithChoicesBase } from '../mixins/CommandOptionWithChoices';
+
+export class SlashCommandNumberOption extends ApplicationCommandOptionWithChoicesBase<number> {
+	public override readonly type = ApplicationCommandOptionType.Number as const;
+
+	public constructor() {
+		super(ApplicationCommandOptionType.Number);
+	}
+}

--- a/tests/SlashCommands.test.ts
+++ b/tests/SlashCommands.test.ts
@@ -5,6 +5,7 @@ import {
 	SlashCommandChannelOption,
 	SlashCommandIntegerOption,
 	SlashCommandMentionableOption,
+	SlashCommandNumberOption,
 	SlashCommandRoleOption,
 	SlashCommandStringOption,
 	SlashCommandSubcommandBuilder,
@@ -18,6 +19,7 @@ const getBuilder = () => new SlashCommandBuilder();
 const getNamedBuilder = () => getBuilder().setName('example').setDescription('Example command');
 const getStringOption = () => new SlashCommandStringOption().setName('owo').setDescription('Testing 123');
 const getIntegerOption = () => new SlashCommandIntegerOption().setName('owo').setDescription('Testing 123');
+const getNumberOption = () => new SlashCommandNumberOption().setName('owo').setDescription('Testing 123');
 const getBooleanOption = () => new SlashCommandBooleanOption().setName('owo').setDescription('Testing 123');
 const getUserOption = () => new SlashCommandUserOption().setName('owo').setDescription('Testing 123');
 const getChannelOption = () => new SlashCommandChannelOption().setName('owo').setDescription('Testing 123');
@@ -129,6 +131,12 @@ describe('Slash Commands', () => {
 								.setDescription('Are we cool or what?')
 								.addChoices([['Very cool', 1_000]]),
 						)
+						.addNumberOption((number) =>
+							number
+								.setName('iscool')
+								.setDescription('Are we cool or what?')
+								.addChoices([['Very cool', 1.5]]),
+						)
 						.addStringOption((string) =>
 							string
 								.setName('iscool')
@@ -147,6 +155,8 @@ describe('Slash Commands', () => {
 				expect(() => getBuilder().addStringOption(getStringOption())).not.toThrowError();
 
 				expect(() => getBuilder().addIntegerOption(getIntegerOption())).not.toThrowError();
+
+				expect(() => getBuilder().addNumberOption(getNumberOption())).not.toThrowError();
 
 				expect(() => getBuilder().addBooleanOption(getBooleanOption())).not.toThrowError();
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This PR adds support for the number option type as is specified [here](https://discord.com/developers/docs/interactions/application-commands#application-command-object-application-command-option-type).

close #22 

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes 
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
<!--
Please move lines that apply to you out of the comment:
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
