### PR TITLE
fix(SlashCommandBuilder): allow subcommands and groups to coexist at the root level

### DIFF
--- a/src/interactions/slashCommands/SlashCommandBuilder.ts
+++ b/src/interactions/slashCommands/SlashCommandBuilder.ts
@@ -50,10 +50,6 @@ export class SlashCommandBuilder {
 		// First, assert options conditions - we cannot have more than 25 options
 		validateMaxOptionsLength(options);
 
-		// Make sure there is no subcommand at the root level - if there is, throw
-		const hasSubcommands = options.some((item) => item instanceof SlashCommandSubcommandBuilder);
-		if (hasSubcommands) throw new RangeError(`You cannot mix subcommands and subcommand groups at the root level.`);
-
 		// Get the final result
 		const result = typeof input === 'function' ? input(new SlashCommandSubcommandGroupBuilder()) : input;
 
@@ -78,11 +74,6 @@ export class SlashCommandBuilder {
 
 		// First, assert options conditions - we cannot have more than 25 options
 		validateMaxOptionsLength(options);
-
-		// Make sure there is no subcommand at the root level - if there is, throw
-		const hasSubcommandGroups = options.some((item) => item instanceof SlashCommandSubcommandGroupBuilder);
-		if (hasSubcommandGroups)
-			throw new RangeError(`You cannot mix subcommands and subcommand groups at the root level.`);
 
 		// Get the final result
 		const result = typeof input === 'function' ? input(new SlashCommandSubcommandBuilder()) : input;

--- a/src/interactions/slashCommands/SlashCommandBuilder.ts
+++ b/src/interactions/slashCommands/SlashCommandBuilder.ts
@@ -44,7 +44,7 @@ export class SlashCommandBuilder {
 		input:
 			| SlashCommandSubcommandGroupBuilder
 			| ((subcommandGroup: SlashCommandSubcommandGroupBuilder) => SlashCommandSubcommandGroupBuilder),
-	): SlashCommandSubcommandsAndSubcommandGroupsOnlyBuilder {
+	): SlashCommandSubcommandsOnlyBuilder {
 		const { options } = this;
 
 		// First, assert options conditions - we cannot have more than 25 options
@@ -69,7 +69,7 @@ export class SlashCommandBuilder {
 		input:
 			| SlashCommandSubcommandBuilder
 			| ((subcommandGroup: SlashCommandSubcommandBuilder) => SlashCommandSubcommandBuilder),
-	): SlashCommandSubcommandsAndSubcommandGroupsOnlyBuilder {
+	): SlashCommandSubcommandsOnlyBuilder {
 		const { options } = this;
 
 		// First, assert options conditions - we cannot have more than 25 options
@@ -89,7 +89,7 @@ export class SlashCommandBuilder {
 
 export interface SlashCommandBuilder extends SharedNameAndDescription, SharedSlashCommandOptions {}
 
-export interface SlashCommandSubcommandsAndSubcommandGroupsOnlyBuilder
+export interface SlashCommandSubcommandsOnlyBuilder
 	extends SharedNameAndDescription,
 		Pick<SlashCommandBuilder, 'toJSON' | 'addSubcommand' | 'addSubcommandGroup'> {}
 

--- a/src/interactions/slashCommands/SlashCommandBuilder.ts
+++ b/src/interactions/slashCommands/SlashCommandBuilder.ts
@@ -44,7 +44,7 @@ export class SlashCommandBuilder {
 		input:
 			| SlashCommandSubcommandGroupBuilder
 			| ((subcommandGroup: SlashCommandSubcommandGroupBuilder) => SlashCommandSubcommandGroupBuilder),
-	): SlashCommandSubcommandGroupsOnlyBuilder {
+	): SlashCommandSubcommandsAndSubcommandGroupsOnlyBuilder {
 		const { options } = this;
 
 		// First, assert options conditions - we cannot have more than 25 options
@@ -69,7 +69,7 @@ export class SlashCommandBuilder {
 		input:
 			| SlashCommandSubcommandBuilder
 			| ((subcommandGroup: SlashCommandSubcommandBuilder) => SlashCommandSubcommandBuilder),
-	): SlashCommandSubcommandsOnlyBuilder {
+	): SlashCommandSubcommandsAndSubcommandGroupsOnlyBuilder {
 		const { options } = this;
 
 		// First, assert options conditions - we cannot have more than 25 options
@@ -89,13 +89,9 @@ export class SlashCommandBuilder {
 
 export interface SlashCommandBuilder extends SharedNameAndDescription, SharedSlashCommandOptions {}
 
-export interface SlashCommandSubcommandsOnlyBuilder
+export interface SlashCommandSubcommandsAndSubcommandGroupsOnlyBuilder
 	extends SharedNameAndDescription,
-		Pick<SlashCommandBuilder, 'toJSON' | 'addSubcommand'> {}
-
-export interface SlashCommandSubcommandGroupsOnlyBuilder
-	extends SharedNameAndDescription,
-		Pick<SlashCommandBuilder, 'toJSON' | 'addSubcommandGroup'> {}
+		Pick<SlashCommandBuilder, 'toJSON' | 'addSubcommand' | 'addSubcommandGroup'> {}
 
 export interface SlashCommandOptionsOnlyBuilder
 	extends SharedNameAndDescription,

--- a/tests/SlashCommands.test.ts
+++ b/tests/SlashCommands.test.ts
@@ -227,17 +227,10 @@ describe('Slash Commands', () => {
 				).not.toThrowError();
 			});
 
-			test('GIVEN builder with a subcommand group that tries to add a subcommand THEN throw error', () => {
-				expect(() =>
-					// @ts-expect-error Checking if check works JS-side too
-					getNamedBuilder().addSubcommandGroup(getSubcommandGroup()).addSubcommand(getSubcommand()),
-				).toThrowError();
-			});
-
 			test('GIVEN builder with a subcommand that tries to add an invalid result THEN throw error', () => {
 				expect(() =>
 					// @ts-expect-error Checking if check works JS-side too
-					getNamedBuilder().addSubcommand(getSubcommand()).addSubcommandGroup(getSubcommandGroup()),
+					getNamedBuilder().addSubcommand(getSubcommand()).addInteger(getInteger()),
 				).toThrowError();
 			});
 


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
As shown in #25 and as confirmed to me in DAPI, the root level of slash commands supports having both subcommands and subcommand groups, but builders does not. This PR removes the checks that prevented this and updates the relevant types. Also, the new return type name is quite lengthy so I'm open to suggestions on a more concise name.

fix #25 

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
<!--
Please move lines that apply to you out of the comment:


- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
