### PR TITLE
feat(ContextMenus): add context menu command builder

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -11,3 +11,6 @@ export * from './interactions/slashCommands/options/number';
 export * from './interactions/slashCommands/options/role';
 export * from './interactions/slashCommands/options/string';
 export * from './interactions/slashCommands/options/user';
+
+export * as ContextMenuCommandAssertions from './interactions/contextMenuCommands/Assertions';
+export * from './interactions/contextMenuCommands/ContextMenuCommandBuilder';

--- a/src/interactions/contextMenuCommands/Assertions.ts
+++ b/src/interactions/contextMenuCommands/Assertions.ts
@@ -1,0 +1,24 @@
+import ow from 'ow';
+
+export function validateRequiredParameters(name: string, type: number) {
+	// Assert name matches all conditions
+	validateName(name);
+
+	// Assert type is valid
+	validateType(type);
+}
+
+const namePredicate = ow.string
+	.minLength(1)
+	.maxLength(32)
+	.matches(/^( *[\p{L}\p{N}_-]+ *)+$/u);
+
+export function validateName(name: unknown): asserts name is string {
+	ow(name, 'name', namePredicate);
+}
+
+const typePredicate = ow.number.inRange(2, 3);
+
+export function validateType(type: unknown): asserts type is number {
+	ow(type, 'type', typePredicate);
+}

--- a/src/interactions/contextMenuCommands/ContextMenuCommandBuilder.ts
+++ b/src/interactions/contextMenuCommands/ContextMenuCommandBuilder.ts
@@ -1,0 +1,52 @@
+import { validateRequiredParameters, validateName, validateType } from './Assertions';
+
+export class ContextMenuCommandBuilder {
+	/**
+	 * The name of this context menu command
+	 */
+	public readonly name: string = undefined!;
+
+	/**
+	 * The type of this context menu command
+	 */
+	public readonly type: number = undefined!;
+
+	/**
+	 * Sets the name
+	 * @param name The name
+	 */
+	public setName(name: string) {
+		// Assert the name matches the conditions
+		validateName(name);
+
+		Reflect.set(this, 'name', name);
+
+		return this;
+	}
+
+	/**
+	 * Sets the type
+	 * @param type The type
+	 */
+	public setType(type: number) {
+		// Assert the type is valid
+		validateType(type);
+
+		Reflect.set(this, 'type', type);
+
+		return this;
+	}
+
+	/**
+	 * Returns the final data that should be sent to Discord.
+	 *
+	 * **Note:** Calling this function will validate required properties based on their conditions.
+	 */
+	public toJSON() {
+		validateRequiredParameters(this.name, this.type);
+		return {
+			name: this.name,
+			type: this.type,
+		};
+	}
+}

--- a/tests/ContextMenuCommands.test.ts
+++ b/tests/ContextMenuCommands.test.ts
@@ -1,0 +1,77 @@
+import { ContextMenuCommandAssertions, ContextMenuCommandBuilder } from '../src/index';
+
+const getBuilder = () => new ContextMenuCommandBuilder();
+
+describe('Context Menu Commands', () => {
+	describe('Assertions tests', () => {
+		test('GIVEN valid name THEN does not throw error', () => {
+			expect(() => ContextMenuCommandAssertions.validateName('ping')).not.toThrowError();
+		});
+
+		test('GIVEN invalid name THEN throw error', () => {
+			expect(() => ContextMenuCommandAssertions.validateName(null)).toThrowError();
+
+			// Too short of a name
+			expect(() => ContextMenuCommandAssertions.validateName('')).toThrowError();
+
+			// Invalid characters used
+			expect(() => ContextMenuCommandAssertions.validateName('ABC123$%^&')).toThrowError();
+
+			// Too long of a name
+			expect(() =>
+				ContextMenuCommandAssertions.validateName('qwertyuiopasdfghjklzxcvbnmqwertyuiopasdfghjklzxcvbnm'),
+			).toThrowError();
+		});
+
+		test('GIVEN valid type THEN does not throw error', () => {
+			expect(() => ContextMenuCommandAssertions.validateType(3)).not.toThrowError();
+		});
+
+		test('GIVEN invalid type THEN throw error', () => {
+			expect(() => ContextMenuCommandAssertions.validateType(null)).toThrowError();
+
+			// Out of range
+			expect(() => ContextMenuCommandAssertions.validateType(1)).toThrowError();
+		});
+
+		test('GIVEN valid required parameters THEN does not throw error', () => {
+			expect(() => ContextMenuCommandAssertions.validateRequiredParameters('owo', 2)).not.toThrowError();
+		});
+	});
+
+	describe('ContextMenuCommandBuilder', () => {
+		describe('Builder tests', () => {
+			test('GIVEN empty builder THEN throw error when calling toJSON', () => {
+				expect(() => getBuilder().toJSON()).toThrowError();
+			});
+
+			test('GIVEN valid builder THEN does not throw error', () => {
+				expect(() => getBuilder().setName('example').setType(3).toJSON()).not.toThrowError();
+			});
+
+			test('GIVEN invalid name THEN throw error', () => {
+				expect(() => getBuilder().setName('$$$')).toThrowError();
+
+				expect(() => getBuilder().setName(' ')).toThrowError();
+			});
+
+			test('GIVEN valid names THEN does not throw error', () => {
+				expect(() => getBuilder().setName('hi_there')).not.toThrowError();
+
+				expect(() => getBuilder().setName('A COMMAND')).not.toThrowError();
+
+				// Translation: a_command
+				expect(() => getBuilder().setName('o_comandă')).not.toThrowError();
+
+				// Translation: thx (according to GTranslate)
+				expect(() => getBuilder().setName('どうも')).not.toThrowError();
+			});
+
+			test('GIVEN valid types THEN does not throw error', () => {
+				expect(() => getBuilder().setType(2)).not.toThrowError();
+
+				expect(() => getBuilder().setType(3)).not.toThrowError();
+			});
+		});
+	});
+});


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Adds context menu command builders according to the docs [here](https://discord.com/developers/docs/interactions/application-commands#application-command-object) and [here](https://discord.com/developers/docs/interactions/application-commands#user-commands).

close #28 

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
<!--
Please move lines that apply to you out of the comment:



- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
