### PR TITLE
fix: properly type `toJSON` methods

### DIFF
--- a/src/interactions/slashCommands/SlashCommandBuilder.ts
+++ b/src/interactions/slashCommands/SlashCommandBuilder.ts
@@ -1,4 +1,4 @@
-import type { APIApplicationCommandOption } from 'discord-api-types/v9';
+import type { APIApplicationCommandOption, RESTPostAPIApplicationCommandsJSONBody } from 'discord-api-types/v9';
 import { mix } from 'ts-mixer';
 import { assertReturnOfBuilder, validateMaxOptionsLength, validateRequiredParameters } from './Assertions';
 import { SharedNameAndDescription } from './mixins/NameAndDescription';
@@ -27,7 +27,7 @@ export class SlashCommandBuilder {
 	 *
 	 * **Note:** Calling this function will validate required properties based on their conditions.
 	 */
-	public toJSON() {
+	public toJSON(): RESTPostAPIApplicationCommandsJSONBody {
 		validateRequiredParameters(this.name, this.description, this.options);
 		return {
 			name: this.name,

--- a/src/interactions/slashCommands/SlashCommandSubcommands.ts
+++ b/src/interactions/slashCommands/SlashCommandSubcommands.ts
@@ -1,4 +1,4 @@
-import { ApplicationCommandOptionType } from 'discord-api-types/v9';
+import { APIApplicationCommandSubCommandOptions, ApplicationCommandOptionType } from 'discord-api-types/v9';
 import { mix } from 'ts-mixer';
 import { assertReturnOfBuilder, validateMaxOptionsLength, validateRequiredParameters } from './Assertions';
 import { SharedSlashCommandOptions } from './mixins/CommandOptions';
@@ -52,7 +52,7 @@ export class SlashCommandSubcommandGroupBuilder implements ToAPIApplicationComma
 		return this;
 	}
 
-	public toJSON() {
+	public toJSON(): APIApplicationCommandSubCommandOptions {
 		validateRequiredParameters(this.name, this.description, this.options);
 		return {
 			type: ApplicationCommandOptionType.SubcommandGroup,
@@ -87,7 +87,7 @@ export class SlashCommandSubcommandBuilder implements ToAPIApplicationCommandOpt
 	 */
 	public readonly options: ToAPIApplicationCommandOptions[] = [];
 
-	public toJSON() {
+	public toJSON(): APIApplicationCommandSubCommandOptions {
 		validateRequiredParameters(this.name, this.description, this.options);
 		return {
 			type: ApplicationCommandOptionType.Subcommand,


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Adds return types for `toJSON` that correspond with `discord-api-types`

**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
