### PR TITLE
Feat: Add support for channel types on channel options

### DIFF
--- a/src/interactions/slashCommands/mixins/CommandChannelOptionBase.ts
+++ b/src/interactions/slashCommands/mixins/CommandChannelOptionBase.ts
@@ -3,7 +3,8 @@ import ow from 'ow';
 import type { ToAPIApplicationCommandOptions } from '../../..';
 import { SlashCommandOptionBase } from './CommandOptionBase';
 
-const channelTypePredicate = ow.number.greaterThanOrEqual(1).lessThanOrEqual(13);
+const channelTypePredicate = ow.number.greaterThanOrEqual(0).lessThanOrEqual(13);
+
 export abstract class ApplicationCommandOptionWithChannelTypesBase
 	extends SlashCommandOptionBase
 	implements ToAPIApplicationCommandOptions
@@ -11,12 +12,16 @@ export abstract class ApplicationCommandOptionWithChannelTypesBase
 	public channelTypes?: ChannelType[];
 
 	public addChannelType(channelType: ChannelType) {
-		ow(channelType, `channel choice name`, channelTypePredicate);
-		this.channelTypes?.push(channelType);
+		this.channelTypes ??= [];
+
+		ow(channelType, `channel type`, channelTypePredicate);
+		this.channelTypes.push(channelType);
+		return this;
 	}
 
-	public setChannelTypes(newChannelTypes: ChannelType[]) {
-		newChannelTypes.forEach(this.addChannelType);
+	public addChannelTypes(newChannelTypes: ChannelType[]) {
+		newChannelTypes.forEach((channelType) => this.addChannelType(channelType));
+		return this;
 	}
 
 	public override toJSON() {

--- a/src/interactions/slashCommands/mixins/CommandChannelOptionBase.ts
+++ b/src/interactions/slashCommands/mixins/CommandChannelOptionBase.ts
@@ -11,16 +11,25 @@ export abstract class ApplicationCommandOptionWithChannelTypesBase
 {
 	public channelTypes?: ChannelType[];
 
+	/**
+	 * Adds a channel type to this option
+	 * @param channelType The type of channel to allow
+	 */
 	public addChannelType(channelType: ChannelType) {
 		this.channelTypes ??= [];
 
 		ow(channelType, `channel type`, channelTypePredicate);
 		this.channelTypes.push(channelType);
+
 		return this;
 	}
 
-	public addChannelTypes(newChannelTypes: ChannelType[]) {
-		newChannelTypes.forEach((channelType) => this.addChannelType(channelType));
+	/**
+	 * Adds channel types to this option
+	 * @param channelTypes The channel types to add
+	 */
+	public addChannelTypes(channelTypes: ChannelType[]) {
+		channelTypes.forEach((channelType) => this.addChannelType(channelType));
 		return this;
 	}
 

--- a/src/interactions/slashCommands/mixins/CommandChannelOptionBase.ts
+++ b/src/interactions/slashCommands/mixins/CommandChannelOptionBase.ts
@@ -1,7 +1,9 @@
 import type { ChannelType } from 'discord-api-types';
+import ow from 'ow';
 import type { ToAPIApplicationCommandOptions } from '../../..';
 import { SlashCommandOptionBase } from './CommandOptionBase';
 
+const channelTypePredicate = ow.number.greaterThanOrEqual(1).lessThanOrEqual(13);
 export abstract class ApplicationCommandOptionWithChannelTypesBase
 	extends SlashCommandOptionBase
 	implements ToAPIApplicationCommandOptions
@@ -9,10 +11,18 @@ export abstract class ApplicationCommandOptionWithChannelTypesBase
 	public channelTypes?: ChannelType[];
 
 	public addChannelType(channelType: ChannelType) {
+		ow(channelType, `channel choice name`, channelTypePredicate);
 		this.channelTypes?.push(channelType);
 	}
 
 	public setChannelTypes(newChannelTypes: ChannelType[]) {
 		newChannelTypes.forEach(this.addChannelType);
+	}
+
+	public override toJSON() {
+		return {
+			...super.toJSON(),
+			channel_types: this.channelTypes,
+		};
 	}
 }

--- a/src/interactions/slashCommands/mixins/CommandChannelOptionBase.ts
+++ b/src/interactions/slashCommands/mixins/CommandChannelOptionBase.ts
@@ -1,0 +1,18 @@
+import type { ChannelType } from 'discord-api-types';
+import type { ToAPIApplicationCommandOptions } from '../../..';
+import { SlashCommandOptionBase } from './CommandOptionBase';
+
+export abstract class ApplicationCommandOptionWithChannelTypesBase
+	extends SlashCommandOptionBase
+	implements ToAPIApplicationCommandOptions
+{
+	public channelTypes?: ChannelType[];
+
+	public addChannelType(channelType: ChannelType) {
+		this.channelTypes?.push(channelType);
+	}
+
+	public setChannelTypes(newChannelTypes: ChannelType[]) {
+		newChannelTypes.forEach(this.addChannelType);
+	}
+}

--- a/src/interactions/slashCommands/mixins/CommandChannelOptionBase.ts
+++ b/src/interactions/slashCommands/mixins/CommandChannelOptionBase.ts
@@ -3,7 +3,9 @@ import ow from 'ow';
 import type { ToAPIApplicationCommandOptions } from '../../..';
 import { SlashCommandOptionBase } from './CommandOptionBase';
 
-const channelTypePredicate = ow.number.greaterThanOrEqual(0).lessThanOrEqual(13);
+// Only allow valid channel types to be used. (This can't be dynamic because const enums are erased at runtime)
+const maxChannelType = 13;
+const channelTypePredicate = ow.number.greaterThanOrEqual(0).lessThanOrEqual(maxChannelType);
 
 export abstract class ApplicationCommandOptionWithChannelTypesBase
 	extends SlashCommandOptionBase

--- a/src/interactions/slashCommands/options/channel.ts
+++ b/src/interactions/slashCommands/options/channel.ts
@@ -1,7 +1,7 @@
 import { ApplicationCommandOptionType } from 'discord-api-types/v9';
-import { SlashCommandOptionBase } from '../mixins/CommandOptionBase';
+import { ApplicationCommandOptionWithChannelTypesBase } from '../mixins/CommandChannelOptionBase';
 
-export class SlashCommandChannelOption extends SlashCommandOptionBase {
+export class SlashCommandChannelOption extends ApplicationCommandOptionWithChannelTypesBase {
 	public override readonly type = ApplicationCommandOptionType.Channel as const;
 
 	public constructor() {

--- a/tests/SlashCommands.test.ts
+++ b/tests/SlashCommands.test.ts
@@ -1,3 +1,4 @@
+import { ChannelType } from 'discord-api-types';
 import {
 	SlashCommandAssertions,
 	SlashCommandBooleanOption,
@@ -157,6 +158,26 @@ describe('Slash Commands', () => {
 						)
 						.toJSON(),
 				).not.toThrowError();
+			});
+
+			test('GIVEN a builder with valid channel options and channel_types THEN does not throw an error', () => {
+				expect(() =>
+					getBuilder().addChannelOption(getChannelOption().addChannelType(ChannelType.GuildText)),
+				).not.toThrowError();
+
+				expect(() => {
+					getBuilder().addChannelOption(
+						getChannelOption().addChannelTypes([ChannelType.GuildNews, ChannelType.GuildText]),
+					);
+				}).not.toThrowError();
+			});
+
+			test('GIVEN a builder with valid channel options and channel_types THEN does throw an error', () => {
+				expect(() => getBuilder().addChannelOption(getChannelOption().addChannelType(100))).toThrowError();
+
+				expect(() => getBuilder().addChannelOption(getChannelOption().addChannelTypes([100, 200]))).toThrowError();
+				// @ts-expect-error
+				expect(() => getBuilder().addBooleanOption(getChannelOption().addChannelType('GuildTest'))).toThrowError();
 			});
 
 			test('GIVEN an already built builder THEN does not throw an error', () => {


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Co-requisite with:
- https://github.com/discordjs/discord-api-types/pull/198

Ref:
- https://github.com/discord/discord-api-docs/pull/3825

**Status and versioning classification:**
Please move lines that apply to you out of the comment:
- Code changes have been tested against the Discord API, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
