### PR TITLE
feat(SlashCommandBuilder): add autocomplete

### DIFF
--- a/src/interactions/slashCommands/mixins/CommandOptionWithChoices.ts
+++ b/src/interactions/slashCommands/mixins/CommandOptionWithChoices.ts
@@ -17,6 +17,7 @@ export abstract class ApplicationCommandOptionWithChoicesBase<T extends string |
 	implements ToAPIApplicationCommandOptions
 {
 	public choices?: APIApplicationCommandOptionChoice[];
+	public autocomplete?: boolean;
 
 	/**
 	 * Adds a choice for this option
@@ -51,10 +52,24 @@ export abstract class ApplicationCommandOptionWithChoicesBase<T extends string |
 		return this;
 	}
 
+	/**
+	 * Marks the option as autocompletable
+	 * @param autocomplete If this option should be autocompletable
+	 */
+	public setAutocomplete(autocomplete: boolean) {
+		// Assert that you actually passed a boolean
+		ow(autocomplete, 'autocomplete', ow.boolean);
+
+		this.autocomplete = autocomplete;
+
+		return this;
+	}
+
 	public override toJSON() {
 		return {
 			...super.toJSON(),
 			choices: this.choices,
+			autocomplete: this.autocomplete,
 		};
 	}
 }


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Adds support for autocompletion. This is a draft because I can't figure out the types to make choices and autocomplete exclusive, so any help on this front would be appreciated. I will add tests once the types are figured out.

Relevant links:
- [Announcement](https://devsnek.notion.site/devsnek/Application-Command-Option-Autocomplete-Interactions-dacc980320c948768cec5ae3a96a5886)
- https://github.com/discord/discord-api-docs/pull/3849
- https://github.com/discordjs/discord-api-types/pull/205
- https://github.com/discordjs/discord.js/pull/6672


**Status and versioning classification:**
- Code changes have been tested against the Discord API, or there are no code changes
- This PR changes the library's interface (methods or parameters added)
<!--
Please move lines that apply to you out of the comment:

- I know how to update typings and have done so, or typings don't need updating

- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
