### PR TITLE
feat(*): replace ow with joi

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
 			"dependencies": {
 				"@sindresorhus/is": "^4.2.0",
 				"discord-api-types": "^0.24.0",
-				"ow": "^0.27.0",
+				"joi": "^17.4.2",
 				"ts-mixer": "^6.0.0",
 				"tslib": "^2.3.1"
 			},
@@ -2138,6 +2138,19 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/@hapi/hoek": {
+			"version": "9.2.1",
+			"resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.2.1.tgz",
+			"integrity": "sha512-gfta+H8aziZsm8pZa0vj04KO6biEiisppNgA1kbJvFrrWu9Vm7eaUEy76DIxsuTaWvti5fkJVhllWc6ZTE+Mdw=="
+		},
+		"node_modules/@hapi/topo": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-5.1.0.tgz",
+			"integrity": "sha512-foQZKJig7Ob0BMAYBfcJk8d77QtOe7Wo4ox7ff1lQYoNNAb6jwcY1ncdoy2e9wQZzvNy7ODZCYJkK8kzmcAnAg==",
+			"dependencies": {
+				"@hapi/hoek": "^9.0.0"
+			}
+		},
 		"node_modules/@humanwhocodes/config-array": {
 			"version": "0.6.0",
 			"resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.6.0.tgz",
@@ -2509,6 +2522,24 @@
 			"engines": {
 				"node": ">= 8"
 			}
+		},
+		"node_modules/@sideway/address": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.2.tgz",
+			"integrity": "sha512-idTz8ibqWFrPU8kMirL0CoPH/A29XOzzAzpyN3zQ4kAWnzmNfFmRaoMNN6VI8ske5M73HZyhIaW4OuSFIdM4oA==",
+			"dependencies": {
+				"@hapi/hoek": "^9.0.0"
+			}
+		},
+		"node_modules/@sideway/formula": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/@sideway/formula/-/formula-3.0.0.tgz",
+			"integrity": "sha512-vHe7wZ4NOXVfkoRb8T5otiENVlT7a3IAiw7H5M2+GO+9CDgcVUUsX1zalAztCmwyOr2RUTGJdgB+ZvSVqmdHmg=="
+		},
+		"node_modules/@sideway/pinpoint": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@sideway/pinpoint/-/pinpoint-2.0.0.tgz",
+			"integrity": "sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ=="
 		},
 		"node_modules/@sindresorhus/is": {
 			"version": "4.2.0",
@@ -3367,6 +3398,7 @@
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
 			"integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+			"dev": true,
 			"engines": {
 				"node": ">=6"
 			}
@@ -6154,6 +6186,7 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/is-obj/-/is-obj-2.0.0.tgz",
 			"integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==",
+			"dev": true,
 			"engines": {
 				"node": ">=8"
 			}
@@ -6928,6 +6961,18 @@
 				"url": "https://github.com/chalk/supports-color?sponsor=1"
 			}
 		},
+		"node_modules/joi": {
+			"version": "17.4.2",
+			"resolved": "https://registry.npmjs.org/joi/-/joi-17.4.2.tgz",
+			"integrity": "sha512-Lm56PP+n0+Z2A2rfRvsfWVDXGEWjXxatPopkQ8qQ5mxCEhwHG+Ettgg5o98FFaxilOxozoa14cFhrE/hOzh/Nw==",
+			"dependencies": {
+				"@hapi/hoek": "^9.0.0",
+				"@hapi/topo": "^5.0.0",
+				"@sideway/address": "^4.1.0",
+				"@sideway/formula": "^3.0.0",
+				"@sideway/pinpoint": "^2.0.0"
+			}
+		},
 		"node_modules/joycon": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/joycon/-/joycon-3.0.1.tgz",
@@ -7290,11 +7335,6 @@
 			"resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
 			"integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
 			"dev": true
-		},
-		"node_modules/lodash.isequal": {
-			"version": "4.5.0",
-			"resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
-			"integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA="
 		},
 		"node_modules/lodash.ismatch": {
 			"version": "4.4.0",
@@ -7931,50 +7971,6 @@
 			},
 			"engines": {
 				"node": ">= 0.8.0"
-			}
-		},
-		"node_modules/ow": {
-			"version": "0.27.0",
-			"resolved": "https://registry.npmjs.org/ow/-/ow-0.27.0.tgz",
-			"integrity": "sha512-SGnrGUbhn4VaUGdU0EJLMwZWSupPmF46hnTRII7aCLCrqixTAC5eKo8kI4/XXf1eaaI8YEVT+3FeGNJI9himAQ==",
-			"dependencies": {
-				"@sindresorhus/is": "^4.0.1",
-				"callsites": "^3.1.0",
-				"dot-prop": "^6.0.1",
-				"lodash.isequal": "^4.5.0",
-				"type-fest": "^1.2.1",
-				"vali-date": "^1.0.0"
-			},
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/ow/node_modules/dot-prop": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-6.0.1.tgz",
-			"integrity": "sha512-tE7ztYzXHIeyvc7N+hR3oi7FIbf/NIjVP9hmAt3yMXzrQ072/fpjGLx2GxNxGxUl5V73MEqYzioOMoVhGMJ5cA==",
-			"dependencies": {
-				"is-obj": "^2.0.0"
-			},
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/ow/node_modules/type-fest": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.4.0.tgz",
-			"integrity": "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==",
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/p-limit": {
@@ -9871,14 +9867,6 @@
 				"node": ">= 8"
 			}
 		},
-		"node_modules/vali-date": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/vali-date/-/vali-date-1.0.0.tgz",
-			"integrity": "sha1-G5BKWWCfsyjvB4E4Qgk09rhnCaY=",
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
 		"node_modules/validate-npm-package-license": {
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
@@ -11639,6 +11627,19 @@
 				}
 			}
 		},
+		"@hapi/hoek": {
+			"version": "9.2.1",
+			"resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.2.1.tgz",
+			"integrity": "sha512-gfta+H8aziZsm8pZa0vj04KO6biEiisppNgA1kbJvFrrWu9Vm7eaUEy76DIxsuTaWvti5fkJVhllWc6ZTE+Mdw=="
+		},
+		"@hapi/topo": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-5.1.0.tgz",
+			"integrity": "sha512-foQZKJig7Ob0BMAYBfcJk8d77QtOe7Wo4ox7ff1lQYoNNAb6jwcY1ncdoy2e9wQZzvNy7ODZCYJkK8kzmcAnAg==",
+			"requires": {
+				"@hapi/hoek": "^9.0.0"
+			}
+		},
 		"@humanwhocodes/config-array": {
 			"version": "0.6.0",
 			"resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.6.0.tgz",
@@ -11930,6 +11931,24 @@
 				"@nodelib/fs.scandir": "2.1.5",
 				"fastq": "^1.6.0"
 			}
+		},
+		"@sideway/address": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.2.tgz",
+			"integrity": "sha512-idTz8ibqWFrPU8kMirL0CoPH/A29XOzzAzpyN3zQ4kAWnzmNfFmRaoMNN6VI8ske5M73HZyhIaW4OuSFIdM4oA==",
+			"requires": {
+				"@hapi/hoek": "^9.0.0"
+			}
+		},
+		"@sideway/formula": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/@sideway/formula/-/formula-3.0.0.tgz",
+			"integrity": "sha512-vHe7wZ4NOXVfkoRb8T5otiENVlT7a3IAiw7H5M2+GO+9CDgcVUUsX1zalAztCmwyOr2RUTGJdgB+ZvSVqmdHmg=="
+		},
+		"@sideway/pinpoint": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@sideway/pinpoint/-/pinpoint-2.0.0.tgz",
+			"integrity": "sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ=="
 		},
 		"@sindresorhus/is": {
 			"version": "4.2.0",
@@ -12587,7 +12606,8 @@
 		"callsites": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
-			"integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ=="
+			"integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+			"dev": true
 		},
 		"camelcase": {
 			"version": "5.3.1",
@@ -14653,7 +14673,8 @@
 		"is-obj": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/is-obj/-/is-obj-2.0.0.tgz",
-			"integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w=="
+			"integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==",
+			"dev": true
 		},
 		"is-plain-obj": {
 			"version": "1.1.0",
@@ -15261,6 +15282,18 @@
 				}
 			}
 		},
+		"joi": {
+			"version": "17.4.2",
+			"resolved": "https://registry.npmjs.org/joi/-/joi-17.4.2.tgz",
+			"integrity": "sha512-Lm56PP+n0+Z2A2rfRvsfWVDXGEWjXxatPopkQ8qQ5mxCEhwHG+Ettgg5o98FFaxilOxozoa14cFhrE/hOzh/Nw==",
+			"requires": {
+				"@hapi/hoek": "^9.0.0",
+				"@hapi/topo": "^5.0.0",
+				"@sideway/address": "^4.1.0",
+				"@sideway/formula": "^3.0.0",
+				"@sideway/pinpoint": "^2.0.0"
+			}
+		},
 		"joycon": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/joycon/-/joycon-3.0.1.tgz",
@@ -15539,11 +15572,6 @@
 			"resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
 			"integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
 			"dev": true
-		},
-		"lodash.isequal": {
-			"version": "4.5.0",
-			"resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
-			"integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA="
 		},
 		"lodash.ismatch": {
 			"version": "4.4.0",
@@ -16041,34 +16069,6 @@
 				"prelude-ls": "^1.2.1",
 				"type-check": "^0.4.0",
 				"word-wrap": "^1.2.3"
-			}
-		},
-		"ow": {
-			"version": "0.27.0",
-			"resolved": "https://registry.npmjs.org/ow/-/ow-0.27.0.tgz",
-			"integrity": "sha512-SGnrGUbhn4VaUGdU0EJLMwZWSupPmF46hnTRII7aCLCrqixTAC5eKo8kI4/XXf1eaaI8YEVT+3FeGNJI9himAQ==",
-			"requires": {
-				"@sindresorhus/is": "^4.0.1",
-				"callsites": "^3.1.0",
-				"dot-prop": "^6.0.1",
-				"lodash.isequal": "^4.5.0",
-				"type-fest": "^1.2.1",
-				"vali-date": "^1.0.0"
-			},
-			"dependencies": {
-				"dot-prop": {
-					"version": "6.0.1",
-					"resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-6.0.1.tgz",
-					"integrity": "sha512-tE7ztYzXHIeyvc7N+hR3oi7FIbf/NIjVP9hmAt3yMXzrQ072/fpjGLx2GxNxGxUl5V73MEqYzioOMoVhGMJ5cA==",
-					"requires": {
-						"is-obj": "^2.0.0"
-					}
-				},
-				"type-fest": {
-					"version": "1.4.0",
-					"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.4.0.tgz",
-					"integrity": "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA=="
-				}
 			}
 		},
 		"p-limit": {
@@ -17476,11 +17476,6 @@
 					"dev": true
 				}
 			}
-		},
-		"vali-date": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/vali-date/-/vali-date-1.0.0.tgz",
-			"integrity": "sha1-G5BKWWCfsyjvB4E4Qgk09rhnCaY="
 		},
 		"validate-npm-package-license": {
 			"version": "3.0.4",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
 	"dependencies": {
 		"@sindresorhus/is": "^4.2.0",
 		"discord-api-types": "^0.24.0",
-		"ow": "^0.27.0",
+		"joi": "^17.4.2",
 		"ts-mixer": "^6.0.0",
 		"tslib": "^2.3.1"
 	},

--- a/src/interactions/contextMenuCommands/Assertions.ts
+++ b/src/interactions/contextMenuCommands/Assertions.ts
@@ -1,4 +1,4 @@
-import ow from 'ow';
+import Joi from 'joi';
 import { ApplicationCommandType } from 'discord-api-types/v9';
 import type { ContextMenuCommandType } from './ContextMenuCommandBuilder';
 
@@ -10,23 +10,25 @@ export function validateRequiredParameters(name: string, type: number) {
 	validateType(type);
 }
 
-const namePredicate = ow.string
-	.minLength(1)
-	.maxLength(32)
-	.matches(/^( *[\p{L}\p{N}_-]+ *)+$/u);
+const namePredicate = Joi.string()
+	.lowercase()
+	.min(1)
+	.max(32)
+	.pattern(/^( *[\p{L}\p{N}_-]+ *)+$/u)
+	.required();
 
 export function validateName(name: unknown): asserts name is string {
-	ow(name, 'name', namePredicate);
+	Joi.assert(name, namePredicate);
 }
 
-const typePredicate = ow.number.oneOf([ApplicationCommandType.User, ApplicationCommandType.Message]);
+const typePredicate = Joi.number().valid(ApplicationCommandType.User, ApplicationCommandType.Message).required();
 
 export function validateType(type: unknown): asserts type is ContextMenuCommandType {
-	ow(type, 'type', typePredicate);
+	Joi.assert(type, typePredicate);
 }
 
-const defaultPermissionPredicate = ow.boolean;
+const defaultPermissionPredicate = Joi.boolean().required();
 
 export function validateDefaultPermission(value: unknown): asserts value is boolean {
-	ow(value, 'default_permission', defaultPermissionPredicate);
+	Joi.assert(value, defaultPermissionPredicate);
 }

--- a/src/interactions/slashCommands/Assertions.ts
+++ b/src/interactions/slashCommands/Assertions.ts
@@ -1,6 +1,6 @@
 import is from '@sindresorhus/is';
 import type { APIApplicationCommandOptionChoice } from 'discord-api-types/v9';
-import ow from 'ow';
+import Joi, { ValidationOptions } from 'joi';
 import type { SlashCommandOptionBase } from './mixins/CommandOptionBase';
 import type { ToAPIApplicationCommandOptions } from './SlashCommandBuilder';
 import type { SlashCommandSubcommandBuilder, SlashCommandSubcommandGroupBuilder } from './SlashCommandSubcommands';
@@ -20,38 +20,37 @@ export function validateRequiredParameters(
 	validateMaxOptionsLength(options);
 }
 
-const namePredicate = ow.string.lowercase
-	.minLength(1)
-	.maxLength(32)
-	.addValidator({
-		message: (value, label) => `Expected ${label!} to match "^[\\p{L}\\p{N}_-]+$", got ${value} instead`,
-		validator: (value) => /^[\p{L}\p{N}_-]+$/u.test(value),
-	});
+const namePredicate = Joi.string()
+	.lowercase()
+	.min(1)
+	.max(32)
+	.pattern(/^[\p{L}\p{N}_-]+$/u)
+	.required();
 
-export function validateName(name: unknown): asserts name is string {
-	ow(name, 'name', namePredicate);
+export function validateName(name: unknown, opts: ValidationOptions | undefined = undefined): asserts name is string {
+	Joi.assert(name, namePredicate, opts);
 }
 
-const descriptionPredicate = ow.string.minLength(1).maxLength(100);
+const descriptionPredicate = Joi.string().min(1).max(100).required();
 
 export function validateDescription(description: unknown): asserts description is string {
-	ow(description, 'description', descriptionPredicate);
+	Joi.assert(description, descriptionPredicate);
 }
 
-const defaultPermissionPredicate = ow.boolean;
+const defaultPermissionPredicate = Joi.boolean().required();
 
 export function validateDefaultPermission(value: unknown): asserts value is boolean {
-	ow(value, 'default_permission', defaultPermissionPredicate);
+	Joi.assert(value, defaultPermissionPredicate);
 }
 
-const maxArrayLengthPredicate = ow.array.maxLength(25);
+const maxArrayLengthPredicate = Joi.array().max(25).required();
 
 export function validateMaxOptionsLength(options: unknown): asserts options is ToAPIApplicationCommandOptions[] {
-	ow(options, 'options', maxArrayLengthPredicate);
+	Joi.assert(options, maxArrayLengthPredicate);
 }
 
 export function validateMaxChoicesLength(choices: APIApplicationCommandOptionChoice[]) {
-	ow(choices, 'choices', maxArrayLengthPredicate);
+	Joi.assert(choices, maxArrayLengthPredicate);
 }
 
 export function assertReturnOfBuilder<

--- a/src/interactions/slashCommands/mixins/CommandChannelOptionBase.ts
+++ b/src/interactions/slashCommands/mixins/CommandChannelOptionBase.ts
@@ -1,5 +1,5 @@
 import { APIApplicationCommandChannelOptions, ApplicationCommandOptionType, ChannelType } from 'discord-api-types/v9';
-import ow from 'ow';
+import Joi from 'joi';
 import type { ToAPIApplicationCommandOptions } from '../../..';
 import { SlashCommandOptionBase } from './CommandOptionBase';
 
@@ -16,7 +16,9 @@ const allowedChannelTypes = [
 	ChannelType.GuildPrivateThread,
 ];
 
-const channelTypePredicate = ow.number.oneOf(allowedChannelTypes);
+const channelTypePredicate = Joi.number()
+	.valid(...allowedChannelTypes)
+	.required();
 
 export abstract class ApplicationCommandOptionWithChannelTypesBase
 	extends SlashCommandOptionBase
@@ -32,7 +34,7 @@ export abstract class ApplicationCommandOptionWithChannelTypesBase
 	public addChannelType(channelType: Exclude<ChannelType, ChannelType.DM | ChannelType.GroupDM>) {
 		this.channelTypes ??= [];
 
-		ow(channelType, 'channel type', channelTypePredicate);
+		Joi.assert(channelType, channelTypePredicate);
 		this.channelTypes.push(channelType);
 
 		return this;

--- a/src/interactions/slashCommands/mixins/CommandOptionBase.ts
+++ b/src/interactions/slashCommands/mixins/CommandOptionBase.ts
@@ -1,5 +1,5 @@
 import type { APIApplicationCommandOption, ApplicationCommandOptionType } from 'discord-api-types/v9';
-import ow from 'ow';
+import Joi from 'joi';
 import { validateRequiredParameters } from '../Assertions';
 import type { ToAPIApplicationCommandOptions } from '../SlashCommandBuilder';
 import { SharedNameAndDescription } from './NameAndDescription';
@@ -20,7 +20,7 @@ export class SlashCommandOptionBase extends SharedNameAndDescription implements 
 	 */
 	public setRequired(required: boolean) {
 		// Assert that you actually passed a boolean
-		ow(required, 'required', ow.boolean);
+		Joi.assert(required, Joi.boolean().required());
 
 		this.required = required;
 
@@ -31,7 +31,7 @@ export class SlashCommandOptionBase extends SharedNameAndDescription implements 
 		validateRequiredParameters(this.name, this.description, []);
 
 		// Assert that you actually passed a boolean
-		ow(this.required, 'required', ow.boolean);
+		Joi.assert(this.required, Joi.boolean().required());
 
 		return {
 			type: this.type,

--- a/src/interactions/slashCommands/mixins/NameAndDescription.ts
+++ b/src/interactions/slashCommands/mixins/NameAndDescription.ts
@@ -11,7 +11,7 @@ export class SharedNameAndDescription {
 	 */
 	public setName(name: string) {
 		// Assert the name matches the conditions
-		validateName(name);
+		validateName(name, { convert: false });
 
 		Reflect.set(this, 'name', name);
 

--- a/src/messages/embed/Assertions.ts
+++ b/src/messages/embed/Assertions.ts
@@ -1,34 +1,35 @@
 import type { APIEmbedField } from 'discord-api-types/v9';
-import ow from 'ow';
+import Joi from 'joi';
 
-export const fieldNamePredicate = ow.string.minLength(1).maxLength(256);
+export const fieldNamePredicate = Joi.string().min(1).max(256).required();
 
-export const fieldValuePredicate = ow.string.minLength(1).maxLength(1024);
+export const fieldValuePredicate = Joi.string().min(1).max(1024).required();
 
-export const fieldInlinePredicate = ow.optional.boolean;
+export const fieldInlinePredicate = Joi.boolean();
 
-export const embedFieldPredicate = ow.object.exactShape({
+export const embedFieldPredicate = Joi.object({
 	name: fieldNamePredicate,
 	value: fieldValuePredicate,
 	inline: fieldInlinePredicate,
 });
 
-export const embedFieldsArrayPredicate = ow.array.ofType(embedFieldPredicate);
+export const embedFieldsArrayPredicate = Joi.array().items(embedFieldPredicate);
 
 export function validateFieldLength(fields: APIEmbedField[], amountAdding: number): void {
-	ow(fields.length + amountAdding, 'field amount', ow.number.lessThanOrEqual(25));
+	const predicate = Joi.number().max(25).required();
+	Joi.assert(fields.length + amountAdding, predicate);
 }
 
-export const authorNamePredicate = ow.any(fieldNamePredicate, ow.null);
+export const authorNamePredicate = fieldNamePredicate.allow(null).required();
 
-export const urlPredicate = ow.any(ow.string.url, ow.nullOrUndefined);
+export const urlPredicate = Joi.string().uri().allow(null).required();
 
-export const colorPredicate = ow.any(ow.number.greaterThanOrEqual(0).lessThanOrEqual(0xffffff), ow.null);
+export const colorPredicate = Joi.number().min(0).max(0xffffff).allow(null).required();
 
-export const descriptionPredicate = ow.any(ow.string.minLength(1).maxLength(4096), ow.null);
+export const descriptionPredicate = Joi.string().min(1).max(4096).allow(null).required();
 
-export const footerTextPredicate = ow.any(ow.string.minLength(1).maxLength(2048), ow.null);
+export const footerTextPredicate = Joi.string().min(1).max(2048).allow(null).required();
 
-export const timestampPredicate = ow.any(ow.number, ow.date, ow.null);
+export const timestampPredicate = Joi.alternatives(Joi.number(), Joi.date(), null).required();
 
-export const titlePredicate = ow.any(fieldNamePredicate, ow.null);
+export const titlePredicate = fieldNamePredicate.allow(null).required();

--- a/src/messages/embed/Embed.ts
+++ b/src/messages/embed/Embed.ts
@@ -8,7 +8,7 @@ import type {
 	APIEmbedThumbnail,
 	APIEmbedVideo,
 } from 'discord-api-types/v9';
-import ow from 'ow';
+import Joi from 'joi';
 import {
 	authorNamePredicate,
 	colorPredicate,
@@ -144,7 +144,7 @@ export class Embed implements APIEmbed {
 	 */
 	public addFields(...fields: APIEmbedField[]): this {
 		// Data assertions
-		ow(fields, 'fields', embedFieldsArrayPredicate);
+		Joi.assert(fields, embedFieldsArrayPredicate);
 
 		// Ensure adding these fields won't exceed the 25 field limit
 		validateFieldLength(this.fields, fields.length);
@@ -162,7 +162,7 @@ export class Embed implements APIEmbed {
 	 */
 	public spliceFields(index: number, deleteCount: number, ...fields: APIEmbedField[]): this {
 		// Data assertions
-		ow(fields, 'fields', embedFieldsArrayPredicate);
+		Joi.assert(fields, embedFieldsArrayPredicate);
 
 		// Ensure adding these fields won't exceed the 25 field limit
 		validateFieldLength(this.fields, fields.length - deleteCount);
@@ -184,9 +184,9 @@ export class Embed implements APIEmbed {
 
 		const { name, iconURL, url } = options;
 		// Data assertions
-		ow(name, 'name', authorNamePredicate);
-		ow(iconURL, 'iconURL', urlPredicate);
-		ow(url, 'url', urlPredicate);
+		Joi.assert(name, authorNamePredicate);
+		Joi.assert(iconURL, urlPredicate);
+		Joi.assert(url, urlPredicate);
 
 		this.author = { name, url, icon_url: iconURL };
 		return this;
@@ -199,7 +199,7 @@ export class Embed implements APIEmbed {
 	 */
 	public setColor(color: number | null): this {
 		// Data assertions
-		ow(color, 'color', colorPredicate);
+		Joi.assert(color, colorPredicate);
 
 		this.color = color ?? undefined;
 		return this;
@@ -212,7 +212,7 @@ export class Embed implements APIEmbed {
 	 */
 	public setDescription(description: string | null): this {
 		// Data assertions
-		ow(description, 'description', descriptionPredicate);
+		Joi.assert(description, descriptionPredicate);
 
 		this.description = description ?? undefined;
 		return this;
@@ -231,8 +231,8 @@ export class Embed implements APIEmbed {
 
 		const { text, iconURL } = options;
 		// Data assertions
-		ow(text, 'text', footerTextPredicate);
-		ow(iconURL, 'iconURL', urlPredicate);
+		Joi.assert(text, footerTextPredicate);
+		Joi.assert(iconURL, urlPredicate);
 
 		this.footer = { text, icon_url: iconURL };
 		return this;
@@ -245,7 +245,7 @@ export class Embed implements APIEmbed {
 	 */
 	public setImage(url: string | null): this {
 		// Data assertions
-		ow(url, 'url', urlPredicate);
+		Joi.assert(url, urlPredicate);
 
 		this.image = url ? { url } : undefined;
 		return this;
@@ -258,7 +258,7 @@ export class Embed implements APIEmbed {
 	 */
 	public setThumbnail(url: string | null): this {
 		// Data assertions
-		ow(url, 'url', urlPredicate);
+		Joi.assert(url, urlPredicate);
 
 		this.thumbnail = url ? { url } : undefined;
 		return this;
@@ -271,7 +271,7 @@ export class Embed implements APIEmbed {
 	 */
 	public setTimestamp(timestamp: number | Date | null = Date.now()): this {
 		// Data assertions
-		ow(timestamp, 'timestamp', timestampPredicate);
+		Joi.assert(timestamp, timestampPredicate);
 
 		this.timestamp = timestamp ? new Date(timestamp).toISOString() : undefined;
 		return this;
@@ -284,7 +284,7 @@ export class Embed implements APIEmbed {
 	 */
 	public setTitle(title: string | null): this {
 		// Data assertions
-		ow(title, 'title', titlePredicate);
+		Joi.assert(title, titlePredicate);
 
 		this.title = title ?? undefined;
 		return this;
@@ -297,7 +297,7 @@ export class Embed implements APIEmbed {
 	 */
 	public setURL(url: string | null): this {
 		// Data assertions
-		ow(url, 'url', urlPredicate);
+		Joi.assert(url, urlPredicate);
 
 		this.url = url ?? undefined;
 		return this;
@@ -317,9 +317,9 @@ export class Embed implements APIEmbed {
 	 */
 	public static normalizeFields(...fields: APIEmbedField[]): APIEmbedField[] {
 		return fields.flat(Infinity).map((field) => {
-			ow(field.name, 'field name', fieldNamePredicate);
-			ow(field.value, 'field value', fieldValuePredicate);
-			ow(field.inline, 'field inline', fieldInlinePredicate);
+			Joi.assert(field.name, fieldNamePredicate);
+			Joi.assert(field.value, fieldValuePredicate);
+			Joi.assert(field.inline, fieldInlinePredicate);
 
 			return { name: field.name, value: field.value, inline: field.inline ?? undefined };
 		});


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Finally fixes #54 (ow hasn't supported ESM in at least 6 months, it likely never did).
To fix ESM, the package author is planning on moving to ESM only, which in turn will break cjs users (they can still use dynamic imports but it's a pretty terrible solution, plus I don't know if the minifier would recognize this and minify accordingly?). So the option was to alienate esm users, or alienate cjs. The best solution I could think of was to just ditch ow.

Another solution would be to remove validation entirely because Discord's documentation is good enough as a reference for users to use instead. Or someone could roll back changes between v0.7.0 and 0.8.x that causes ow to get used in `SlashCommandBuilder`?

[Another user experiencing the same issue](https://discord.com/channels/222078108977594368/878205247569408011/904377258104479795).

**Status and versioning classification:**

- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added) - **_changes the errors and likely breaks other things, however all tests pass_**
- Code changes have been tested, or there are no code changes
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
<!--
Please move lines that apply to you out of the comment:
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
