### PR TITLE
chore: update dapi types and fix errors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@sindresorhus/is": "^4.2.0",
-				"discord-api-types": "^0.24.0",
+				"discord-api-types": "^0.25.0",
 				"ow": "^0.27.0",
 				"ts-mixer": "^6.0.0",
 				"tslib": "^2.3.1"
@@ -4161,9 +4161,9 @@
 			}
 		},
 		"node_modules/discord-api-types": {
-			"version": "0.24.0",
-			"resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.24.0.tgz",
-			"integrity": "sha512-X0uA2a92cRjowUEXpLZIHWl4jiX1NsUpDhcEOpa1/hpO1vkaokgZ8kkPtPih9hHth5UVQ3mHBu/PpB4qjyfJ4A==",
+			"version": "0.25.0",
+			"resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.25.0.tgz",
+			"integrity": "sha512-LS5TZAARsDVcJaljxplec25L9ampP2aY6rf1SFRowK66RTLdyVn0Gal3VsF+mYBhZDkeFd+awBNoJmUeECBoPQ==",
 			"engines": {
 				"node": ">=12"
 			}
@@ -13205,9 +13205,9 @@
 			}
 		},
 		"discord-api-types": {
-			"version": "0.24.0",
-			"resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.24.0.tgz",
-			"integrity": "sha512-X0uA2a92cRjowUEXpLZIHWl4jiX1NsUpDhcEOpa1/hpO1vkaokgZ8kkPtPih9hHth5UVQ3mHBu/PpB4qjyfJ4A=="
+			"version": "0.25.0",
+			"resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.25.0.tgz",
+			"integrity": "sha512-LS5TZAARsDVcJaljxplec25L9ampP2aY6rf1SFRowK66RTLdyVn0Gal3VsF+mYBhZDkeFd+awBNoJmUeECBoPQ=="
 		},
 		"doctrine": {
 			"version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
 	"homepage": "https://github.com/discordjs/builders",
 	"dependencies": {
 		"@sindresorhus/is": "^4.2.0",
-		"discord-api-types": "^0.24.0",
+		"discord-api-types": "^0.25.0",
 		"ow": "^0.27.0",
 		"ts-mixer": "^6.0.0",
 		"tslib": "^2.3.1"

--- a/src/interactions/slashCommands/mixins/CommandChannelOptionBase.ts
+++ b/src/interactions/slashCommands/mixins/CommandChannelOptionBase.ts
@@ -19,7 +19,7 @@ const allowedChannelTypes = [
 const channelTypePredicate = ow.number.oneOf(allowedChannelTypes);
 
 export abstract class ApplicationCommandOptionWithChannelTypesBase
-	extends SlashCommandOptionBase
+	extends SlashCommandOptionBase<ApplicationCommandOptionType.Channel>
 	implements ToAPIApplicationCommandOptions
 {
 	public channelTypes?: Exclude<ChannelType, ChannelType.DM | ChannelType.GroupDM>[];
@@ -51,8 +51,9 @@ export abstract class ApplicationCommandOptionWithChannelTypesBase
 	public override toJSON(): APIApplicationCommandChannelOptions {
 		return {
 			...super.toJSON(),
-			type: ApplicationCommandOptionType.Channel,
+			type: this.type,
 			channel_types: this.channelTypes,
+			autocomplete: undefined,
 		};
 	}
 }

--- a/src/interactions/slashCommands/mixins/CommandChannelOptionBase.ts
+++ b/src/interactions/slashCommands/mixins/CommandChannelOptionBase.ts
@@ -55,11 +55,12 @@ export abstract class ApplicationCommandOptionWithChannelTypesBase
 	}
 
 	public override toJSON(): APIApplicationCommandChannelOptions {
+		// TODO: Fix types
+		// eslint-disable-next-line @typescript-eslint/consistent-type-assertions
 		return {
 			...super.toJSON(),
 			type: this.type,
 			channel_types: this.channelTypes,
-			autocomplete: undefined,
-		};
+		} as APIApplicationCommandChannelOptions;
 	}
 }

--- a/src/interactions/slashCommands/mixins/CommandOptionBase.ts
+++ b/src/interactions/slashCommands/mixins/CommandOptionBase.ts
@@ -35,12 +35,13 @@ export class SlashCommandOptionBase<OptionType extends ApplicationCommandOptionT
 		// Assert that you actually passed a boolean
 		validateRequired(this.required);
 
+		// TODO: Fix types
+		// eslint-disable-next-line @typescript-eslint/consistent-type-assertions
 		return {
 			type: this.type,
 			name: this.name,
 			description: this.description,
 			required: this.required,
-			autocomplete: undefined,
-		};
+		} as APIApplicationCommandOption;
 	}
 }

--- a/src/interactions/slashCommands/mixins/CommandOptionBase.ts
+++ b/src/interactions/slashCommands/mixins/CommandOptionBase.ts
@@ -4,11 +4,14 @@ import { validateRequiredParameters } from '../Assertions';
 import type { ToAPIApplicationCommandOptions } from '../SlashCommandBuilder';
 import { SharedNameAndDescription } from './NameAndDescription';
 
-export class SlashCommandOptionBase extends SharedNameAndDescription implements ToAPIApplicationCommandOptions {
+export class SlashCommandOptionBase<OptionType extends ApplicationCommandOptionType = ApplicationCommandOptionType>
+	extends SharedNameAndDescription
+	implements ToAPIApplicationCommandOptions
+{
 	public required = false;
-	public readonly type: ApplicationCommandOptionType;
+	public readonly type: OptionType;
 
-	public constructor(type: ApplicationCommandOptionType) {
+	public constructor(type: OptionType) {
 		super();
 		this.type = type;
 	}
@@ -38,6 +41,7 @@ export class SlashCommandOptionBase extends SharedNameAndDescription implements 
 			name: this.name,
 			description: this.description,
 			required: this.required,
+			autocomplete: undefined,
 		};
 	}
 }

--- a/src/interactions/slashCommands/mixins/CommandOptionWithChoices.ts
+++ b/src/interactions/slashCommands/mixins/CommandOptionWithChoices.ts
@@ -13,7 +13,9 @@ const choicesPredicate = ow.array.ofType<[string, string | number]>(
 );
 
 export abstract class ApplicationCommandOptionWithChoicesBase<T extends string | number>
-	extends SlashCommandOptionBase
+	extends SlashCommandOptionBase<
+		ApplicationCommandOptionType.String | ApplicationCommandOptionType.Number | ApplicationCommandOptionType.Integer
+	>
 	implements ToAPIApplicationCommandOptions
 {
 	public choices?: APIApplicationCommandOptionChoice[];

--- a/src/interactions/slashCommands/mixins/CommandOptionWithChoices.ts
+++ b/src/interactions/slashCommands/mixins/CommandOptionWithChoices.ts
@@ -1,4 +1,8 @@
-import { APIApplicationCommandOptionChoice, ApplicationCommandOptionType } from 'discord-api-types/v9';
+import {
+	APIApplicationCommandOption,
+	APIApplicationCommandOptionChoice,
+	ApplicationCommandOptionType,
+} from 'discord-api-types/v9';
 import { z } from 'zod';
 import { validateMaxChoicesLength } from '../Assertions';
 import type { ToAPIApplicationCommandOptions } from '../SlashCommandBuilder';
@@ -87,10 +91,12 @@ export abstract class ApplicationCommandOptionWithChoicesBase<T extends string |
 			throw new RangeError('Autocomplete and choices are mutually exclusive to each other.');
 		}
 
+		// TODO: Fix types
+		// eslint-disable-next-line @typescript-eslint/consistent-type-assertions
 		return {
 			...super.toJSON(),
 			choices: this.choices,
 			autocomplete: this.autocomplete,
-		};
+		} as APIApplicationCommandOption;
 	}
 }


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This adds support for the latest dapi-types. Some changes to the structures needed to be made to make builders compatible with the new types. `SlashCommandOptionBase` is now generic and accepts an optional `ApplicationCommandOptionType`.

**Status and versioning classification:**
- Code changes have been tested, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR changes the library's interface (methods or parameters added)
