### PR TITLE
fix(ApplicationCommandOptions): ensure toJSON return is valid

### DIFF
--- a/__tests__/interactions/ContextMenuCommands.test.ts
+++ b/__tests__/interactions/ContextMenuCommands.test.ts
@@ -1,4 +1,4 @@
-import { ContextMenuCommandAssertions, ContextMenuCommandBuilder } from '../src/index';
+import { ContextMenuCommandAssertions, ContextMenuCommandBuilder } from '../../src/index';
 
 const getBuilder = () => new ContextMenuCommandBuilder();
 

--- a/__tests__/interactions/SlashCommands/Options.test.ts
+++ b/__tests__/interactions/SlashCommands/Options.test.ts
@@ -35,10 +35,20 @@ const getStringOption = () =>
 	new SlashCommandStringOption().setName('owo').setDescription('Testing 123').setRequired(true);
 
 const getIntegerOption = () =>
-	new SlashCommandIntegerOption().setName('owo').setDescription('Testing 123').setRequired(true);
+	new SlashCommandIntegerOption()
+		.setName('owo')
+		.setDescription('Testing 123')
+		.setRequired(true)
+		.setMinValue(1)
+		.setMaxValue(10);
 
 const getNumberOption = () =>
-	new SlashCommandNumberOption().setName('owo').setDescription('Testing 123').setRequired(true);
+	new SlashCommandNumberOption()
+		.setName('owo')
+		.setDescription('Testing 123')
+		.setRequired(true)
+		.setMinValue(1)
+		.setMaxValue(10);
 
 const getUserOption = () => new SlashCommandUserOption().setName('owo').setDescription('Testing 123').setRequired(true);
 
@@ -73,6 +83,8 @@ describe('Application Command toJSON() results', () => {
 			description: 'Testing 123',
 			type: ApplicationCommandOptionType.Integer,
 			required: true,
+			max_value: 10,
+			min_value: 1,
 		});
 
 		expect(
@@ -82,6 +94,8 @@ describe('Application Command toJSON() results', () => {
 			description: 'Testing 123',
 			type: ApplicationCommandOptionType.Integer,
 			required: true,
+			max_value: 10,
+			min_value: 1,
 			autocomplete: true,
 			// @ts-expect-error TODO: you *can* send an empty array with autocomplete: true, should correct that in types
 			choices: [],
@@ -92,6 +106,8 @@ describe('Application Command toJSON() results', () => {
 			description: 'Testing 123',
 			type: ApplicationCommandOptionType.Integer,
 			required: true,
+			max_value: 10,
+			min_value: 1,
 			choices: [{ name: 'uwu', value: 1 }],
 		});
 	});
@@ -111,6 +127,8 @@ describe('Application Command toJSON() results', () => {
 			description: 'Testing 123',
 			type: ApplicationCommandOptionType.Number,
 			required: true,
+			max_value: 10,
+			min_value: 1,
 		});
 
 		expect(getNumberOption().setAutocomplete(true).setChoices([]).toJSON()).toEqual<APIApplicationCommandNumberOption>({
@@ -118,6 +136,8 @@ describe('Application Command toJSON() results', () => {
 			description: 'Testing 123',
 			type: ApplicationCommandOptionType.Number,
 			required: true,
+			max_value: 10,
+			min_value: 1,
 			autocomplete: true,
 			// @ts-expect-error TODO: you *can* send an empty array with autocomplete: true, should correct that in types
 			choices: [],
@@ -128,6 +148,8 @@ describe('Application Command toJSON() results', () => {
 			description: 'Testing 123',
 			type: ApplicationCommandOptionType.Number,
 			required: true,
+			max_value: 10,
+			min_value: 1,
 			choices: [{ name: 'uwu', value: 1 }],
 		});
 	});

--- a/__tests__/interactions/SlashCommands/Options.test.ts
+++ b/__tests__/interactions/SlashCommands/Options.test.ts
@@ -1,0 +1,179 @@
+import {
+	APIApplicationCommandBooleanOption,
+	APIApplicationCommandChannelOption,
+	APIApplicationCommandIntegerOption,
+	APIApplicationCommandMentionableOption,
+	APIApplicationCommandNumberOption,
+	APIApplicationCommandRoleOption,
+	APIApplicationCommandStringOption,
+	APIApplicationCommandUserOption,
+	ApplicationCommandOptionType,
+	ChannelType,
+} from 'discord-api-types/v9';
+import {
+	SlashCommandBooleanOption,
+	SlashCommandChannelOption,
+	SlashCommandIntegerOption,
+	SlashCommandMentionableOption,
+	SlashCommandNumberOption,
+	SlashCommandRoleOption,
+	SlashCommandStringOption,
+	SlashCommandUserOption,
+} from '../../../src/index';
+
+const getBooleanOption = () =>
+	new SlashCommandBooleanOption().setName('owo').setDescription('Testing 123').setRequired(true);
+
+const getChannelOption = () =>
+	new SlashCommandChannelOption()
+		.setName('owo')
+		.setDescription('Testing 123')
+		.setRequired(true)
+		.addChannelType(ChannelType.GuildText);
+
+const getStringOption = () =>
+	new SlashCommandStringOption().setName('owo').setDescription('Testing 123').setRequired(true);
+
+const getIntegerOption = () =>
+	new SlashCommandIntegerOption().setName('owo').setDescription('Testing 123').setRequired(true);
+
+const getNumberOption = () =>
+	new SlashCommandNumberOption().setName('owo').setDescription('Testing 123').setRequired(true);
+
+const getUserOption = () => new SlashCommandUserOption().setName('owo').setDescription('Testing 123').setRequired(true);
+
+const getRoleOption = () => new SlashCommandRoleOption().setName('owo').setDescription('Testing 123').setRequired(true);
+
+const getMentionableOption = () =>
+	new SlashCommandMentionableOption().setName('owo').setDescription('Testing 123').setRequired(true);
+
+describe('Application Command toJSON() results', () => {
+	test('GIVEN a boolean option THEN calling toJSON should return a valid JSON', () => {
+		expect(getBooleanOption().toJSON()).toEqual<APIApplicationCommandBooleanOption>({
+			name: 'owo',
+			description: 'Testing 123',
+			type: ApplicationCommandOptionType.Boolean,
+			required: true,
+		});
+	});
+
+	test('GIVEN a channel option THEN calling toJSON should return a valid JSON', () => {
+		expect(getChannelOption().toJSON()).toEqual<APIApplicationCommandChannelOption>({
+			name: 'owo',
+			description: 'Testing 123',
+			type: ApplicationCommandOptionType.Channel,
+			required: true,
+			channel_types: [ChannelType.GuildText],
+		});
+	});
+
+	test('GIVEN a integer option THEN calling toJSON should return a valid JSON', () => {
+		expect(getIntegerOption().toJSON()).toEqual<APIApplicationCommandIntegerOption>({
+			name: 'owo',
+			description: 'Testing 123',
+			type: ApplicationCommandOptionType.Integer,
+			required: true,
+		});
+
+		expect(
+			getIntegerOption().setAutocomplete(true).setChoices([]).toJSON(),
+		).toEqual<APIApplicationCommandIntegerOption>({
+			name: 'owo',
+			description: 'Testing 123',
+			type: ApplicationCommandOptionType.Integer,
+			required: true,
+			autocomplete: true,
+			// @ts-expect-error TODO: you *can* send an empty array with autocomplete: true, should correct that in types
+			choices: [],
+		});
+
+		expect(getIntegerOption().addChoice('uwu', 1).toJSON()).toEqual<APIApplicationCommandIntegerOption>({
+			name: 'owo',
+			description: 'Testing 123',
+			type: ApplicationCommandOptionType.Integer,
+			required: true,
+			choices: [{ name: 'uwu', value: 1 }],
+		});
+	});
+
+	test('GIVEN a mentionable option THEN calling toJSON should return a valid JSON', () => {
+		expect(getMentionableOption().toJSON()).toEqual<APIApplicationCommandMentionableOption>({
+			name: 'owo',
+			description: 'Testing 123',
+			type: ApplicationCommandOptionType.Mentionable,
+			required: true,
+		});
+	});
+
+	test('GIVEN a number option THEN calling toJSON should return a valid JSON', () => {
+		expect(getNumberOption().toJSON()).toEqual<APIApplicationCommandNumberOption>({
+			name: 'owo',
+			description: 'Testing 123',
+			type: ApplicationCommandOptionType.Number,
+			required: true,
+		});
+
+		expect(getNumberOption().setAutocomplete(true).setChoices([]).toJSON()).toEqual<APIApplicationCommandNumberOption>({
+			name: 'owo',
+			description: 'Testing 123',
+			type: ApplicationCommandOptionType.Number,
+			required: true,
+			autocomplete: true,
+			// @ts-expect-error TODO: you *can* send an empty array with autocomplete: true, should correct that in types
+			choices: [],
+		});
+
+		expect(getNumberOption().addChoice('uwu', 1).toJSON()).toEqual<APIApplicationCommandNumberOption>({
+			name: 'owo',
+			description: 'Testing 123',
+			type: ApplicationCommandOptionType.Number,
+			required: true,
+			choices: [{ name: 'uwu', value: 1 }],
+		});
+	});
+
+	test('GIVEN a role option THEN calling toJSON should return a valid JSON', () => {
+		expect(getRoleOption().toJSON()).toEqual<APIApplicationCommandRoleOption>({
+			name: 'owo',
+			description: 'Testing 123',
+			type: ApplicationCommandOptionType.Role,
+			required: true,
+		});
+	});
+
+	test('GIVEN a string option THEN calling toJSON should return a valid JSON', () => {
+		expect(getStringOption().toJSON()).toEqual<APIApplicationCommandStringOption>({
+			name: 'owo',
+			description: 'Testing 123',
+			type: ApplicationCommandOptionType.String,
+			required: true,
+		});
+
+		expect(getStringOption().setAutocomplete(true).setChoices([]).toJSON()).toEqual<APIApplicationCommandStringOption>({
+			name: 'owo',
+			description: 'Testing 123',
+			type: ApplicationCommandOptionType.String,
+			required: true,
+			autocomplete: true,
+			// @ts-expect-error TODO: you *can* send an empty array with autocomplete: true, should correct that in types
+			choices: [],
+		});
+
+		expect(getStringOption().addChoice('uwu', '1').toJSON()).toEqual<APIApplicationCommandStringOption>({
+			name: 'owo',
+			description: 'Testing 123',
+			type: ApplicationCommandOptionType.String,
+			required: true,
+			choices: [{ name: 'uwu', value: '1' }],
+		});
+	});
+
+	test('GIVEN a user option THEN calling toJSON should return a valid JSON', () => {
+		expect(getUserOption().toJSON()).toEqual<APIApplicationCommandUserOption>({
+			name: 'owo',
+			description: 'Testing 123',
+			type: ApplicationCommandOptionType.User,
+			required: true,
+		});
+	});
+});

--- a/__tests__/interactions/SlashCommands/SlashCommands.test.ts
+++ b/__tests__/interactions/SlashCommands/SlashCommands.test.ts
@@ -12,7 +12,7 @@ import {
 	SlashCommandSubcommandBuilder,
 	SlashCommandSubcommandGroupBuilder,
 	SlashCommandUserOption,
-} from '../src/index';
+} from '../../../src/index';
 
 const largeArray = Array.from({ length: 26 }, () => 1 as unknown as APIApplicationCommandOptionChoice);
 
@@ -337,7 +337,7 @@ describe('Slash Commands', () => {
 				).not.toThrowError();
 			});
 
-			test('GIVEN an option that is autocompletable and has choices, THEN setting choices should throw an error', () => {
+			test('GIVEN an option that is autocompletable, THEN setting choices should throw an error', () => {
 				expect(() =>
 					getBuilder().addStringOption(
 						getStringOption()
@@ -345,6 +345,10 @@ describe('Slash Commands', () => {
 							.setChoices([['owo', 'uwu']]),
 					),
 				).toThrowError();
+			});
+
+			test('GIVEN an option, THEN setting choices should not throw an error', () => {
+				expect(() => getBuilder().addStringOption(getStringOption().setChoices([['owo', 'uwu']]))).not.toThrowError();
 			});
 		});
 

--- a/src/interactions/slashCommands/mixins/ApplicationCommandNumericOptionMinMaxValueMixin.ts
+++ b/src/interactions/slashCommands/mixins/ApplicationCommandNumericOptionMinMaxValueMixin.ts
@@ -1,6 +1,6 @@
 export abstract class ApplicationCommandNumericOptionMinMaxValueMixin {
-	protected readonly maxValue?: number;
-	protected readonly minValue?: number;
+	public readonly max_value?: number;
+	public readonly min_value?: number;
 
 	/**
 	 * Sets the maximum number value of this option

--- a/src/interactions/slashCommands/mixins/NameAndDescription.ts
+++ b/src/interactions/slashCommands/mixins/NameAndDescription.ts
@@ -9,7 +9,7 @@ export class SharedNameAndDescription {
 	 *
 	 * @param name The name
 	 */
-	public setName(name: string) {
+	public setName(name: string): this {
 		// Assert the name matches the conditions
 		validateName(name);
 

--- a/src/interactions/slashCommands/options/integer.ts
+++ b/src/interactions/slashCommands/options/integer.ts
@@ -17,7 +17,7 @@ export class SlashCommandIntegerOption
 	public setMaxValue(max: number): this {
 		numberValidator.parse(max);
 
-		Reflect.set(this, 'maxValue', max);
+		Reflect.set(this, 'max_value', max);
 
 		return this;
 	}
@@ -25,7 +25,7 @@ export class SlashCommandIntegerOption
 	public setMinValue(min: number): this {
 		numberValidator.parse(min);
 
-		Reflect.set(this, 'minValue', min);
+		Reflect.set(this, 'min_value', min);
 
 		return this;
 	}

--- a/src/interactions/slashCommands/options/number.ts
+++ b/src/interactions/slashCommands/options/number.ts
@@ -17,7 +17,7 @@ export class SlashCommandNumberOption
 	public setMaxValue(max: number): this {
 		numberValidator.parse(max);
 
-		Reflect.set(this, 'maxValue', max);
+		Reflect.set(this, 'max_value', max);
 
 		return this;
 	}
@@ -25,7 +25,7 @@ export class SlashCommandNumberOption
 	public setMinValue(min: number): this {
 		numberValidator.parse(min);
 
-		Reflect.set(this, 'minValue', min);
+		Reflect.set(this, 'min_value', min);
 
 		return this;
 	}


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

Small mistake in number options made max and minValues to not get properly passed to api snake_case properties. This PR fixes that and also adds tests t

**Status and versioning classification:**

- Code changes have been tested, or there are no code changes
- I know how to update typings and have done so, or typings don't need updating
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed) ⭐ (technically this was private properties that are now also public...so it's not breaking per say)
